### PR TITLE
Add resilient workspace file transfer, member management, and account-level usage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ bioos --help
 
 The CLI is organized by resource groups such as `workspace`, `workflow`, `submission`, `file`, `ies`, `dockstore`, and `docker`.
 
+## Highlights
+
+This release expands the unified `bioos` CLI in three main areas:
+
+- resilient workspace file upload with checkpoint resume and retry support
+- workspace member management commands
+- account-level usage and resource query commands
+
+It also makes workflow local-file preprocessing more robust and allows downloads from current-workspace `s3://...` paths.
+
 ## Installation
 
 Install from PyPI:
@@ -163,6 +173,33 @@ List workspace files:
 bioos file list --workspace-name my-workspace --recursive
 ```
 
+Upload local files to a workspace:
+
+```bash
+bioos file upload \
+  --workspace-name my-workspace \
+  --source ./inputs/sample1.fastq.gz \
+  --source ./inputs/sample2.fastq.gz \
+  --target input_provision/ \
+  --skip-existing
+```
+
+List workspace members:
+
+```bash
+bioos workspace member list \
+  --workspace-name my-workspace \
+  --page-size 100
+```
+
+Query account-level usage:
+
+```bash
+bioos usage resource-total \
+  --start-time 1776214800 \
+  --end-time 1776301200
+```
+
 ## CLI Overview
 
 Top-level command groups:
@@ -202,6 +239,163 @@ Current workspace commands:
 - `bioos workspace export`
 - `bioos workspace profile`
 - `bioos workspace dashboard-upload`
+- `bioos workspace member list`
+- `bioos workspace member add`
+- `bioos workspace member update`
+- `bioos workspace member delete`
+
+Current file commands:
+
+- `bioos file upload`
+- `bioos file list`
+- `bioos file download`
+- `bioos file delete`
+
+Current usage commands:
+
+- `bioos usage asset-data`
+- `bioos usage asset-list`
+- `bioos usage asset-total`
+- `bioos usage resource-data`
+- `bioos usage resource-workspace-list`
+- `bioos usage resource-user-list`
+- `bioos usage resource-total`
+
+## File Transfer
+
+### Upload
+
+`bioos file upload` uploads one or more local files into the current workspace bucket.
+
+Key capabilities:
+
+- multiple `--source` inputs in one command
+- multipart upload for large files
+- resumable uploads with checkpoint files
+- per-file retry controls
+- `--skip-existing` support
+- shared upload behavior reused by workflow local-file preprocessing
+
+Example:
+
+```bash
+bioos file upload \
+  --workspace-name my-workspace \
+  --source ./data/sample.bam \
+  --target input_provision/ \
+  --checkpoint-dir ~/.bioos/upload-checkpoints \
+  --max-retries 3 \
+  --task-num 10
+```
+
+Available upload options:
+
+- `--workspace-name`: target workspace name
+- `--source`: local file path, can be repeated
+- `--target`: target prefix in the workspace bucket
+- `--flatten/--no-flatten`: control whether local directory structure is preserved
+- `--skip-existing`: skip upload when the target key already exists
+- `--checkpoint-dir`: checkpoint directory for resumable multipart uploads
+- `--max-retries`: retry count per file after the first attempt
+- `--task-num`: multipart parallel task count
+
+### Download
+
+`bioos file download` supports:
+
+- internal workspace object keys such as `input_provision/a.txt`
+- current-workspace `s3://bucket/key` paths
+
+If an `s3://...` path points to a different bucket than the current workspace bucket, the CLI raises a clear bucket mismatch error instead of attempting a cross-workspace download.
+
+## Workflow Local File Preprocessing
+
+`bioos workflow submit` automatically scans `input.json` for local file paths before submission.
+
+Compared with the earlier implementation, the current behavior is more robust:
+
+- recursively traverses real JSON structures instead of regex-scanning the serialized JSON string
+- supports singleton `{...}` and batch `[{...}, {...}]` inputs
+- correctly recognizes Chinese paths and paths containing spaces
+- preserves non-local values such as `drs://...` and existing `s3://...`
+- replaces only exact matched local-path values with uploaded `s3://...` locations
+
+This preprocessing path reuses the same resilient upload helper as `bioos file upload`.
+
+## Workspace Member Management
+
+Workspace member operations are available under `bioos workspace member`.
+
+Examples:
+
+```bash
+bioos workspace member list \
+  --workspace-name my-workspace \
+  --page-size 100
+
+bioos workspace member add \
+  --workspace-name my-workspace \
+  --name alice \
+  --name bob \
+  --role User
+
+bioos workspace member update \
+  --workspace-name my-workspace \
+  --name alice \
+  --role Admin
+
+bioos workspace member delete \
+  --workspace-name my-workspace \
+  --name alice
+```
+
+Notes:
+
+- `member list` defaults to `InWorkspace=true`, so it lists users already in the workspace
+- `member list` also supports `--page-number`, `--page-size`, `--keyword`, `--role`, and `--no-in-workspace`
+- supported member roles are `Visitor`, `User`, and `Admin`
+
+## Account-Level Usage Queries
+
+Account-level usage commands are available under `bioos usage`.
+
+Examples:
+
+```bash
+bioos usage asset-total \
+  --start-time 1776214800 \
+  --end-time 1776301200 \
+  --type WorkspaceVisit
+
+bioos usage resource-user-list \
+  --start-time 1776214800 \
+  --end-time 1776301200
+
+bioos usage resource-data \
+  --start-time 1776214800 \
+  --end-time 1776301200 \
+  --type cpu
+```
+
+Notes:
+
+- usage APIs are account-level, not workspace-scoped
+- some usage APIs are only available to the account owner
+- when a sub-account calls owner-only usage APIs, pybioos returns a clearer permission error instead of exposing the raw backend error payload
+
+## Compatibility Notes
+
+- `tos` is still pinned to `2.5.6` in this release
+- `pandas>=1.3.0` is still supported in this release
+- workflow batch preprocessing currently uses a temporary `DataFrame.map/applymap` compatibility shim so the same code can run on both older pandas releases and newer environments such as pandas 3.x
+- this pandas compatibility shim is transitional and is expected to be removed in the next release after the minimum supported pandas version is raised to `2.1+`
+- legacy commands such as `bw` and `bw_import` are still available for compatibility, but new integrations should use the unified `bioos` command tree
+
+## Current Limitations
+
+- directory upload is not supported yet; `bioos file upload` currently accepts files, not whole directories
+- `bioos file download` does not yet support direct signed `https://...` download URLs
+- usage commands depend on backend permissions; owner-only APIs require the main account AK/SK
 
 ## Python SDK Example
 

--- a/bioos/__about__.py
+++ b/bioos/__about__.py
@@ -1,4 +1,4 @@
 # coding:utf-8
 
 # Package version
-__version__ = "0.0.22"
+__version__ = "0.0.23"

--- a/bioos/bioos.py
+++ b/bioos/bioos.py
@@ -2,6 +2,7 @@ from pandas import DataFrame
 from volcengine.const.Const import REGION_CN_NORTH1
 
 from bioos.config import Config,DEFAULT_ENDPOINT
+from bioos.resource.usage import UsageResource
 from bioos.resource.utility import UtilityResource
 from bioos.resource.workspaces import Workspace
 
@@ -113,3 +114,12 @@ def utility() -> UtilityResource:
     :rtype: UtilityResource
     """
     return UtilityResource()
+
+
+def usage() -> UsageResource:
+    """Returns the account-level usage resource object.
+
+    :return: Usage resource object
+    :rtype: UsageResource
+    """
+    return UsageResource()

--- a/bioos/bioos_workflow.py
+++ b/bioos/bioos_workflow.py
@@ -13,6 +13,7 @@ from bioos import bioos
 from bioos.config import DEFAULT_ENDPOINT
 from bioos.errors import NotFoundError, ParameterError
 from bioos.ops.auth import login_to_bioos
+from bioos.ops.workspace_files import _upload_local_files_with_workspace
 
 
 def uniquify_columns(cols: list[str]) -> list[str]:
@@ -46,6 +47,59 @@ def recognize_files_from_input_json(workflow_input_json: dict) -> dict:
     return putative_files
 
 
+def collect_local_file_paths(value: Any) -> set[str]:
+    paths = set()
+
+    if isinstance(value, dict):
+        for nested_value in value.values():
+            paths.update(collect_local_file_paths(nested_value))
+        return paths
+
+    if isinstance(value, list):
+        for nested_value in value:
+            paths.update(collect_local_file_paths(nested_value))
+        return paths
+
+    if not isinstance(value, str):
+        return paths
+
+    if value.startswith("s3"):
+        return paths
+
+    if "registry-vpc" in value:
+        return paths
+
+    if os.path.isfile(value):
+        paths.add(value)
+
+    return paths
+
+
+def replace_local_paths_with_s3(value: Any, source_to_s3: dict[str, str]) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: replace_local_paths_with_s3(nested_value, source_to_s3)
+            for key, nested_value in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            replace_local_paths_with_s3(nested_value, source_to_s3)
+            for nested_value in value
+        ]
+
+    if isinstance(value, str):
+        return source_to_s3.get(value, value)
+
+    return value
+
+
+def dataframe_map_compat(df: pd.DataFrame, func):
+    # version in setup.py to 2.1+, where DataFrame.map is available.
+    if hasattr(df, "map"):
+        return df.map(func)
+    return df.applymap(func)
+
 def get_logger():
     global LOGGER
 
@@ -69,6 +123,7 @@ class Bioos_workflow:
     def __init__(self, workspace_name: str, workflow_name: str) -> None:
         # global LOGGER
         self.logger = get_logger()
+        self.workspace_name = workspace_name
 
         # get workspace id
         df = bioos.list_workspaces()
@@ -76,6 +131,7 @@ class Bioos_workflow:
         if len(ser) != 1:
             raise NotFoundError("Workspace", workspace_name)
         workspace_id = ser.to_list()[0]
+        self.workspace_id = workspace_id
 
         self.ws = bioos.workspace(workspace_id)
         self.wf = self.ws.workflow(name=workflow_name)
@@ -124,7 +180,8 @@ class Bioos_workflow:
                    submission_desc: str = "Submit by pybioos",
                    call_caching: bool = True,
                    force_reupload: bool = False):
-        input_json = json.load(open(input_json_file))
+        with open(input_json_file, encoding="utf-8") as handle:
+            input_json = json.load(handle)
         self.logger.info("Load json input successfully.")
 
         # 将单例的模式转换成向量形式
@@ -159,7 +216,10 @@ class Bioos_workflow:
 
         # 这里可能要对每次新上传的datamodel进行重命名
         # 这里经证实只支持全str类型的df
-        self.ws.data_models.write({data_model_name: df.map(str)}, force=True)
+        self.ws.data_models.write(
+            {data_model_name: dataframe_map_compat(df, str)},
+            force=True,
+        )
         self.logger.info("Set data model successfully.")
 
         # 生成veapi需要的输入结构
@@ -192,20 +252,11 @@ class Bioos_workflow:
         if data_model_name == "dm":
             data_model_name = f"dm_{int(time.time())}"
 
-        input_json = json.load(open(input_json_file))
+        with open(input_json_file, encoding="utf-8") as handle:
+            input_json = json.load(handle)
         self.logger.info("Load json input successfully.")
 
-        # putative files
-        input_json_str = json.dumps(input_json)
-
-        # capture strings containing "/" the test if the file exists
-        putative_files = [
-            s.strip('"\'') for s in re.findall(
-                r'''"[-_\w./:]+?/[-_\w./:]+?"''', input_json_str)
-            if os.path.isfile(s.strip('"\''))
-        ]
-
-        putative_files = set(putative_files)
+        putative_files = collect_local_file_paths(input_json)
         file_str = ''
         for putative_file in putative_files:
             file_str = file_str + '\t' + putative_file + '\n'
@@ -214,22 +265,27 @@ class Bioos_workflow:
             f"Putative files need to upload includes:\n{file_str}")
 
         # provision upload and file path replace
-        df = self.ws.files.list('input_provision')
-        uploaded_files = [] if df.empty else df.key.to_list()
-        for putative_file in putative_files:
-            target = f"input_provision/{os.path.basename(putative_file)}"
-
-            if not force_reupload and target in uploaded_files:
+        source_to_s3 = {}
+        if putative_files:
+            upload_result = _upload_local_files_with_workspace(
+                ws=self.ws,
+                workspace_id=self.workspace_id,
+                workspace_name=self.workspace_name,
+                sources=sorted(putative_files),
+                target="input_provision/",
+                flatten=True,
+                skip_existing=not force_reupload,
+            )
+            for uploaded_file in upload_result["uploaded_files"]:
+                self.logger.info(f"Finish upload {uploaded_file['source']}.")
+            for skipped_file in upload_result["skipped_files"]:
                 self.logger.info(
-                    f"Skip target site already existed file {putative_file}.")
-            else:
-                self.logger.info(f"Start upload {putative_file}.")
-                self.ws.files.upload(putative_file,
-                                     target="input_provision/",
-                                     flatten=True)
-                self.logger.info(f"Finish upload {putative_file}.")
-            s3_location = self.ws.files.s3_urls(target)[0]
-            input_json_str = re.sub(putative_file, s3_location, input_json_str)
+                    f"Skip target site already existed file {skipped_file['source']}.")
+            source_to_s3 = {
+                item["source"]: item["s3_url"]
+                for item in upload_result["uploaded_files"] + upload_result["skipped_files"]
+            }
+        input_json = replace_local_paths_with_s3(input_json, source_to_s3)
 
         # start build params_submit
         self.params_submit = {
@@ -240,7 +296,6 @@ class Bioos_workflow:
         }
 
         # if the input json is a batch or singleton submission
-        input_json = json.loads(input_json_str)
         if isinstance(input_json, list):  # batch mode
             self.logger.info("Batch mode found.")
 
@@ -265,7 +320,7 @@ class Bioos_workflow:
             df.columns = pd.Index(uniquify_columns(df.columns.to_list()))
 
             # write data models
-            self.ws.data_models.write({data_model_name: df.applymap(str)},
+            self.ws.data_models.write({data_model_name: dataframe_map_compat(df, str)},
                                       force=True)
             self.logger.info("Set data model successfully.")
 

--- a/bioos/cli/add_workspace_members.py
+++ b/bioos/cli/add_workspace_members.py
@@ -1,0 +1,45 @@
+import sys
+
+from bioos.cli.common import add_argument, build_parser, run_cli
+from bioos.ops.auth import workspace_context_from_args
+
+
+def build_args():
+    parser = build_parser("Add members to a workspace.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        parser,
+        "name",
+        required=False,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    add_argument(
+        parser,
+        "role",
+        required=True,
+        help="Workspace member role: Visitor, User, or Admin.",
+    )
+    return parser
+
+
+def handle(args):
+    _, ws = workspace_context_from_args(args)
+    result = ws.add_members(names=args.name, role=args.role)
+    return {
+        "success": True,
+        "workspace_name": args.workspace_name,
+        "role": args.role,
+        "names": args.name,
+        "result": result,
+    }
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/delete_workspace_members.py
+++ b/bioos/cli/delete_workspace_members.py
@@ -1,0 +1,38 @@
+import sys
+
+from bioos.cli.common import add_argument, build_parser, run_cli
+from bioos.ops.auth import workspace_context_from_args
+
+
+def build_args():
+    parser = build_parser("Delete members from a workspace.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        parser,
+        "name",
+        required=False,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    return parser
+
+
+def handle(args):
+    _, ws = workspace_context_from_args(args)
+    result = ws.delete_members(names=args.name)
+    return {
+        "success": True,
+        "workspace_name": args.workspace_name,
+        "names": args.name,
+        "result": result,
+    }
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/list_workspace_members.py
+++ b/bioos/cli/list_workspace_members.py
@@ -1,0 +1,58 @@
+import sys
+
+from bioos.cli.common import add_argument, add_bool_argument, build_parser, run_cli
+from bioos.ops.auth import workspace_context_from_args
+
+
+def build_args():
+    parser = build_parser("List workspace members.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(parser, "page_number", required=False, type=int, help="Page number.")
+    add_argument(parser, "page_size", required=False, type=int, help="Page size.")
+    add_bool_argument(
+        parser,
+        "in_workspace",
+        default=True,
+        help_text="Only list users already in the workspace.",
+    )
+    add_argument(
+        parser,
+        "role",
+        required=False,
+        action="append",
+        help="Optional member role filter. Can be specified multiple times.",
+    )
+    add_argument(
+        parser,
+        "keyword",
+        required=False,
+        help="Optional username keyword filter.",
+    )
+    return parser
+
+
+def handle(args):
+    _, ws = workspace_context_from_args(args)
+    members = ws.list_members(
+        page_number=args.page_number,
+        page_size=args.page_size,
+        in_workspace=args.in_workspace,
+        roles=args.role,
+        keyword=args.keyword,
+    )
+    return {
+        "success": True,
+        "workspace_name": args.workspace_name,
+        "in_workspace": args.in_workspace,
+        "members": members,
+    }
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/main.py
+++ b/bioos/cli/main.py
@@ -4,11 +4,13 @@ from typing import Any, Iterable, Optional
 
 from bioos import bioos_workflow, bw_import, bw_import_status_check, bw_status_check, get_submission_logs
 from bioos.cli import (
+    add_workspace_members,
     build_docker_image,
     check_build_status,
     check_ies_status,
     create_iesapp,
     create_workspace_bioos,
+    delete_workspace_members,
     delete_submission,
     download_files_from_workspace,
     export_bioos_workspace,
@@ -19,10 +21,14 @@ from bioos.cli import (
     get_workspace_profile,
     list_bioos_workspaces,
     list_files_from_workspace,
+    list_workspace_members,
     list_submissions_from_workspace,
     list_workflows_from_workspace,
     search_dockstore,
     upload_dashboard_file,
+    upload_files_to_workspace,
+    usage_metrics,
+    update_workspace_members,
     validate_wdl,
 )
 from bioos.cli.common import add_argument, add_auth_arguments, add_bool_argument, add_output_arguments, run_cli
@@ -43,6 +49,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_workflow_group(subparsers)
     _add_submission_group(subparsers)
     _add_file_group(subparsers)
+    _add_usage_group(subparsers)
     _add_ies_group(subparsers)
     _add_dockstore_group(subparsers)
     _add_docker_group(subparsers)
@@ -179,6 +186,92 @@ def _add_workspace_group(subparsers: Any) -> None:
     add_argument(dashboard_parser, "local_file_path", required=True, help="Path to __dashboard__.md.")
     dashboard_parser.set_defaults(_parser=dashboard_parser)
     dashboard_parser.set_defaults(handler=upload_dashboard_file.handle)
+
+    member_parser = workspace_subparsers.add_parser("member", help="Workspace member management commands.")
+    member_subparsers = member_parser.add_subparsers(dest="member_command")
+    member_parser.set_defaults(_parser=member_parser)
+
+    member_list_parser = member_subparsers.add_parser("list", help="List workspace members.")
+    add_auth_arguments(member_list_parser)
+    add_output_arguments(member_list_parser)
+    add_argument(member_list_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(member_list_parser, "page_number", required=False, type=int, help="Page number.")
+    add_argument(member_list_parser, "page_size", required=False, type=int, help="Page size.")
+    add_bool_argument(
+        member_list_parser,
+        "in_workspace",
+        default=True,
+        help_text="Only list users already in the workspace.",
+    )
+    add_argument(
+        member_list_parser,
+        "role",
+        required=False,
+        action="append",
+        help="Optional member role filter. Can be specified multiple times.",
+    )
+    add_argument(
+        member_list_parser,
+        "keyword",
+        required=False,
+        help="Optional username keyword filter.",
+    )
+    member_list_parser.set_defaults(_parser=member_list_parser)
+    member_list_parser.set_defaults(handler=list_workspace_members.handle)
+
+    member_add_parser = member_subparsers.add_parser("add", help="Add members to a workspace.")
+    add_auth_arguments(member_add_parser)
+    add_output_arguments(member_add_parser)
+    add_argument(member_add_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        member_add_parser,
+        "name",
+        required=False,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    add_argument(
+        member_add_parser,
+        "role",
+        required=True,
+        help="Workspace member role: Visitor, User, or Admin.",
+    )
+    member_add_parser.set_defaults(_parser=member_add_parser)
+    member_add_parser.set_defaults(handler=add_workspace_members.handle)
+
+    member_update_parser = member_subparsers.add_parser("update", help="Update workspace members.")
+    add_auth_arguments(member_update_parser)
+    add_output_arguments(member_update_parser)
+    add_argument(member_update_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        member_update_parser,
+        "name",
+        required=True,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    add_argument(
+        member_update_parser,
+        "role",
+        required=True,
+        help="Workspace member role: Visitor, User, or Admin.",
+    )
+    member_update_parser.set_defaults(_parser=member_update_parser)
+    member_update_parser.set_defaults(handler=update_workspace_members.handle)
+
+    member_delete_parser = member_subparsers.add_parser("delete", help="Delete members from a workspace.")
+    add_auth_arguments(member_delete_parser)
+    add_output_arguments(member_delete_parser)
+    add_argument(member_delete_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        member_delete_parser,
+        "name",
+        required=False,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    member_delete_parser.set_defaults(_parser=member_delete_parser)
+    member_delete_parser.set_defaults(handler=delete_workspace_members.handle)
 
 
 def _add_workflow_group(subparsers: Any) -> None:
@@ -325,6 +418,51 @@ def _add_file_group(subparsers: Any) -> None:
     file_subparsers = file_parser.add_subparsers(dest="file_command")
     file_parser.set_defaults(_parser=file_parser)
 
+    upload_parser = file_subparsers.add_parser("upload", help="Upload local files to a workspace.")
+    add_auth_arguments(upload_parser)
+    add_output_arguments(upload_parser)
+    add_argument(upload_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        upload_parser,
+        "source",
+        required=True,
+        action="append",
+        help="Local file path. Can be specified multiple times.",
+    )
+    add_argument(upload_parser, "target", required=False, default="", help="Target prefix path in the workspace bucket.")
+    add_bool_argument(upload_parser, "flatten", default=True, help_text="Flatten local paths during upload.")
+    add_bool_argument(
+        upload_parser,
+        "skip_existing",
+        default=False,
+        help_text="Skip files whose target object already exists.",
+    )
+    add_argument(
+        upload_parser,
+        "checkpoint_dir",
+        required=False,
+        default=None,
+        help="Directory for resumable upload checkpoints.",
+    )
+    add_argument(
+        upload_parser,
+        "max_retries",
+        required=False,
+        type=int,
+        default=3,
+        help="Number of retries per file after the initial attempt.",
+    )
+    add_argument(
+        upload_parser,
+        "task_num",
+        required=False,
+        type=int,
+        default=10,
+        help="Parallel task count for multipart uploads.",
+    )
+    upload_parser.set_defaults(_parser=upload_parser)
+    upload_parser.set_defaults(handler=upload_files_to_workspace.handle)
+
     list_parser = file_subparsers.add_parser("list", help="List files from a workspace.")
     add_auth_arguments(list_parser)
     add_output_arguments(list_parser)
@@ -414,6 +552,129 @@ def _add_ies_group(subparsers: Any) -> None:
     add_argument(events_parser, "ies_name", required=True, help="IES instance name.")
     events_parser.set_defaults(_parser=events_parser)
     events_parser.set_defaults(handler=get_ies_events.handle)
+
+
+def _add_usage_group(subparsers: Any) -> None:
+    usage_parser = subparsers.add_parser("usage", help="Account-level usage and asset metrics.")
+    usage_subparsers = usage_parser.add_subparsers(dest="usage_command")
+    usage_parser.set_defaults(_parser=usage_parser)
+
+    asset_data_parser = usage_subparsers.add_parser("asset-data", help="Get asset usage time-series data.")
+    add_auth_arguments(asset_data_parser)
+    add_output_arguments(asset_data_parser)
+    add_argument(asset_data_parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(asset_data_parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        asset_data_parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    asset_data_parser.set_defaults(_parser=asset_data_parser)
+    asset_data_parser.set_defaults(handler=usage_metrics.handle_asset_usage_data)
+
+    asset_list_parser = usage_subparsers.add_parser("asset-list", help="List asset usage records.")
+    add_auth_arguments(asset_list_parser)
+    add_output_arguments(asset_list_parser)
+    add_argument(asset_list_parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(asset_list_parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        asset_list_parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    asset_list_parser.set_defaults(_parser=asset_list_parser)
+    asset_list_parser.set_defaults(handler=usage_metrics.handle_asset_usage_list)
+
+    asset_total_parser = usage_subparsers.add_parser("asset-total", help="Get total asset usage.")
+    add_auth_arguments(asset_total_parser)
+    add_output_arguments(asset_total_parser)
+    add_argument(asset_total_parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(asset_total_parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        asset_total_parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    asset_total_parser.set_defaults(_parser=asset_total_parser)
+    asset_total_parser.set_defaults(handler=usage_metrics.handle_asset_usage_total)
+
+    resource_data_parser = usage_subparsers.add_parser("resource-data", help="Get resource usage time-series data.")
+    add_auth_arguments(resource_data_parser)
+    add_output_arguments(resource_data_parser)
+    add_argument(resource_data_parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(resource_data_parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        resource_data_parser,
+        "type",
+        required=True,
+        help="Resource usage type: cpu, memory, storage, tos, or gpu.",
+    )
+    add_argument(
+        resource_data_parser,
+        "sub_dimension",
+        required=False,
+        action="append",
+        help="Optional sub-dimension. Can be specified multiple times.",
+    )
+    resource_data_parser.set_defaults(_parser=resource_data_parser)
+    resource_data_parser.set_defaults(handler=usage_metrics.handle_resource_usage_data)
+
+    resource_workspace_list_parser = usage_subparsers.add_parser(
+        "resource-workspace-list",
+        help="List workspace resource usage.",
+    )
+    add_auth_arguments(resource_workspace_list_parser)
+    add_output_arguments(resource_workspace_list_parser)
+    add_argument(
+        resource_workspace_list_parser,
+        "start_time",
+        required=True,
+        type=int,
+        help="Start timestamp at an exact hour.",
+    )
+    add_argument(
+        resource_workspace_list_parser,
+        "end_time",
+        required=True,
+        type=int,
+        help="End timestamp at an exact hour.",
+    )
+    resource_workspace_list_parser.set_defaults(_parser=resource_workspace_list_parser)
+    resource_workspace_list_parser.set_defaults(handler=usage_metrics.handle_workspace_resource_usage)
+
+    resource_user_list_parser = usage_subparsers.add_parser(
+        "resource-user-list",
+        help="List user resource usage.",
+    )
+    add_auth_arguments(resource_user_list_parser)
+    add_output_arguments(resource_user_list_parser)
+    add_argument(
+        resource_user_list_parser,
+        "start_time",
+        required=True,
+        type=int,
+        help="Start timestamp at an exact hour.",
+    )
+    add_argument(
+        resource_user_list_parser,
+        "end_time",
+        required=True,
+        type=int,
+        help="End timestamp at an exact hour.",
+    )
+    resource_user_list_parser.set_defaults(_parser=resource_user_list_parser)
+    resource_user_list_parser.set_defaults(handler=usage_metrics.handle_user_resource_usage)
+
+    resource_total_parser = usage_subparsers.add_parser("resource-total", help="Get total resource usage.")
+    add_auth_arguments(resource_total_parser)
+    add_output_arguments(resource_total_parser)
+    add_argument(resource_total_parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(resource_total_parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    resource_total_parser.set_defaults(_parser=resource_total_parser)
+    resource_total_parser.set_defaults(handler=usage_metrics.handle_total_resource_usage)
 
 
 def _add_dockstore_group(subparsers: Any) -> None:

--- a/bioos/cli/update_workspace_members.py
+++ b/bioos/cli/update_workspace_members.py
@@ -1,0 +1,45 @@
+import sys
+
+from bioos.cli.common import add_argument, build_parser, run_cli
+from bioos.ops.auth import workspace_context_from_args
+
+
+def build_args():
+    parser = build_parser("Update workspace members.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        parser,
+        "name",
+        required=True,
+        action="append",
+        help="Member username. Can be specified multiple times.",
+    )
+    add_argument(
+        parser,
+        "role",
+        required=True,
+        help="Workspace member role: Visitor, User, or Admin.",
+    )
+    return parser
+
+
+def handle(args):
+    _, ws = workspace_context_from_args(args)
+    result = ws.update_members(names=args.name, role=args.role)
+    return {
+        "success": True,
+        "workspace_name": args.workspace_name,
+        "role": args.role,
+        "names": args.name,
+        "result": result,
+    }
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/upload_files_to_workspace.py
+++ b/bioos/cli/upload_files_to_workspace.py
@@ -1,0 +1,69 @@
+import sys
+
+from bioos.cli.common import add_argument, add_bool_argument, build_parser, run_cli
+from bioos.ops.workspace_files import upload_local_files_to_workspace
+
+
+def build_args():
+    parser = build_parser("Upload local files to a Bio-OS workspace.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(
+        parser,
+        "source",
+        required=True,
+        action="append",
+        help="Local file path. Can be specified multiple times.",
+    )
+    add_argument(parser, "target", required=False, default="", help="Target prefix path in the workspace bucket.")
+    add_bool_argument(parser, "flatten", default=True, help_text="Flatten local paths during upload.")
+    add_bool_argument(parser, "skip_existing", default=False, help_text="Skip files whose target object already exists.")
+    add_argument(
+        parser,
+        "checkpoint_dir",
+        required=False,
+        default=None,
+        help="Directory for resumable upload checkpoints.",
+    )
+    add_argument(
+        parser,
+        "max_retries",
+        required=False,
+        type=int,
+        default=3,
+        help="Number of retries per file after the initial attempt.",
+    )
+    add_argument(
+        parser,
+        "task_num",
+        required=False,
+        type=int,
+        default=10,
+        help="Parallel task count for multipart uploads.",
+    )
+    return parser
+
+
+def handle(args):
+    return upload_local_files_to_workspace(
+        workspace_name=args.workspace_name,
+        sources=args.source,
+        target=args.target,
+        flatten=args.flatten,
+        skip_existing=args.skip_existing,
+        checkpoint_dir=args.checkpoint_dir,
+        max_retries=args.max_retries,
+        task_num=args.task_num,
+        access_key=args.ak,
+        secret_key=args.sk,
+        endpoint=args.endpoint,
+    )
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/usage_metrics.py
+++ b/bioos/cli/usage_metrics.py
@@ -1,0 +1,195 @@
+import sys
+
+from bioos.cli.common import add_argument, build_parser, run_cli
+from bioos.ops.auth import login_with_args
+
+
+def build_asset_usage_data_args():
+    parser = build_parser("Get asset usage time-series data.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    return parser
+
+
+def build_asset_usage_list_args():
+    parser = build_parser("List asset usage records.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    return parser
+
+
+def build_asset_usage_total_args():
+    parser = build_parser("Get total asset usage.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        parser,
+        "type",
+        required=True,
+        help="Asset usage type: WorkspaceVisit or WorkflowUse.",
+    )
+    return parser
+
+
+def build_resource_usage_data_args():
+    parser = build_parser("Get resource usage time-series data.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    add_argument(
+        parser,
+        "type",
+        required=True,
+        help="Resource usage type: cpu, memory, storage, tos, or gpu.",
+    )
+    add_argument(
+        parser,
+        "sub_dimension",
+        required=False,
+        action="append",
+        help="Optional sub-dimension. Can be specified multiple times.",
+    )
+    return parser
+
+
+def build_workspace_resource_usage_args():
+    parser = build_parser("List workspace resource usage.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    return parser
+
+
+def build_user_resource_usage_args():
+    parser = build_parser("List user resource usage.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    return parser
+
+
+def build_total_resource_usage_args():
+    parser = build_parser("Get total resource usage.")
+    add_argument(parser, "start_time", required=True, type=int, help="Start timestamp at an exact hour.")
+    add_argument(parser, "end_time", required=True, type=int, help="End timestamp at an exact hour.")
+    return parser
+
+
+def handle_asset_usage_data(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().get_asset_usage_data(args.start_time, args.end_time, args.type)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "type": args.type,
+        "result": result,
+    }
+
+
+def handle_asset_usage_list(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().list_asset_usage(args.start_time, args.end_time, args.type)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "type": args.type,
+        "result": result,
+    }
+
+
+def handle_asset_usage_total(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().get_total_asset_usage(args.start_time, args.end_time, args.type)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "type": args.type,
+        "result": result,
+    }
+
+
+def handle_resource_usage_data(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().get_resource_usage_data(
+        args.start_time,
+        args.end_time,
+        args.type,
+        sub_dimensions=args.sub_dimension,
+    )
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "type": args.type,
+        "sub_dimensions": args.sub_dimension,
+        "result": result,
+    }
+
+
+def handle_workspace_resource_usage(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().list_workspace_resource_usage(args.start_time, args.end_time)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "result": result,
+    }
+
+
+def handle_user_resource_usage(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().list_user_resource_usage(args.start_time, args.end_time)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "result": result,
+    }
+
+
+def handle_total_resource_usage(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    result = bioos.usage().get_total_resource_usage(args.start_time, args.end_time)
+    return {
+        "success": True,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "result": result,
+    }
+
+
+def main():
+    parser = build_asset_usage_data_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_asset_usage_data, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/internal/tos.py
+++ b/bioos/internal/tos.py
@@ -1,3 +1,4 @@
+import hashlib
 import math
 import os
 import re
@@ -70,6 +71,96 @@ class TOSHandler:
                                            self._bucket, file_path,
                                            duration).signed_url
 
+    def object_exists(self, file_path: str) -> bool:
+        try:
+            self._client.head_object(bucket=self._bucket, key=file_path)
+            return True
+        except tos.exceptions.TosServerError as err:
+            if err.status_code == 404:
+                return False
+            raise
+
+    def _resolve_upload_key(self,
+                            file_path: str,
+                            target_path: str,
+                            flatten: bool) -> str:
+        if flatten:
+            to_upload_path = os.path.basename(file_path)
+        else:
+            to_upload_path = os.path.normpath(file_path)
+
+        if os.path.isabs(to_upload_path):
+            to_upload_path = to_upload_path.lstrip("/")
+
+        return os.path.normpath(os.path.join(target_path, to_upload_path))
+
+    def _build_upload_checkpoint_file(self,
+                                      file_path: str,
+                                      tos_target_path: str,
+                                      checkpoint_dir: str) -> str:
+        if not checkpoint_dir:
+            return None
+
+        resolved_checkpoint_dir = os.path.abspath(
+            os.path.expanduser(checkpoint_dir))
+        os.makedirs(resolved_checkpoint_dir, exist_ok=True)
+        checkpoint_key = hashlib.sha256(
+            f"{self._bucket}\0{tos_target_path}\0{os.path.abspath(file_path)}".
+            encode("utf-8")).hexdigest()
+        return os.path.join(resolved_checkpoint_dir,
+                            f"{checkpoint_key}.upload.ckpt")
+
+    def _upload_small_file(self, file_path: str, tos_target_path: str):
+        self._client.put_object_from_file(
+            bucket=self._bucket,
+            key=tos_target_path,
+            file_path=file_path,
+            # don't show progress while uploading small file
+            # data_transfer_listener=tos_percentage
+        )
+
+    def _upload_big_file(self,
+                         file_path: str,
+                         tos_target_path: str,
+                         fsize: int,
+                         checkpoint_dir: str,
+                         task_num: int):
+        part_size = max(int(fsize / MAX_ALLOWED_PARTS) + 1, MIN_PART_SIZE)
+        checkpoint_file = self._build_upload_checkpoint_file(
+            file_path, tos_target_path, checkpoint_dir)
+        self._client.upload_file(
+            bucket=self._bucket,
+            key=tos_target_path,
+            file_path=file_path,
+            part_size=part_size,
+            task_num=task_num,
+            enable_checkpoint=checkpoint_file is not None,
+            checkpoint_file=checkpoint_file,
+            data_transfer_listener=tos_percentage)
+
+    def _upload_with_retry(self,
+                           file_path: str,
+                           tos_target_path: str,
+                           fsize: int,
+                           checkpoint_dir: str,
+                           max_retries: int,
+                           task_num: int):
+        total_attempts = max_retries + 1
+        for attempt_index in range(total_attempts):
+            try:
+                if fsize <= SIMPLE_UPLOAD_LIMITATION:
+                    self._upload_small_file(file_path, tos_target_path)
+                else:
+                    self._upload_big_file(file_path, tos_target_path, fsize,
+                                          checkpoint_dir, task_num)
+                return
+            except Exception as err:
+                if attempt_index == total_attempts - 1:
+                    raise
+                self._warn_logging(
+                    f"upload {tos_target_path} failed on attempt "
+                    f"{attempt_index + 1}/{total_attempts}: {err}. Retrying...")
+
     def list_objects(self, target_path: str, num: int) -> List[ListedObject]:
         object_list = []
         if num != 0:
@@ -121,30 +212,17 @@ class TOSHandler:
         flatten: bool,
         ignore: str = "",
         include: str = "",
+        checkpoint_dir: str = "",
+        max_retries: int = 3,
+        task_num: int = DEFAULT_THREAD,
     ) -> List[str]:
 
         def _upload_fail(error_list_: List[str], file_path_: str):
             error_list_.append(file_path_)
 
-        def _upload_small_file(file_path_, tos_target_path_):
-            self._client.put_object_from_file(
-                bucket=self._bucket,
-                key=tos_target_path_,
-                file_path=file_path_,
-                # don't show progress while uploading small file
-                # data_transfer_listener=tos_percentage
-            )
-
-        def _upload_big_file(file_path_, tos_target_path_, fsize_):
-            part_size = max(int(fsize_ / MAX_ALLOWED_PARTS) + 1, MIN_PART_SIZE)
-            self._client.upload_file(bucket=self._bucket,
-                                     key=tos_target_path_,
-                                     file_path=file_path_,
-                                     part_size=part_size,
-                                     task_num=DEFAULT_THREAD,
-                                     data_transfer_listener=tos_percentage)
-
         files_to_upload = self.files_filter(files_to_upload, include, ignore)
+        max_retries = max(int(max_retries) if max_retries is not None else 3, 0)
+        task_num = max(int(task_num) if task_num is not None else DEFAULT_THREAD, 1)
         if len(files_to_upload) == 0:
             self._info_logging("no files to upload")
             return []
@@ -156,17 +234,8 @@ class TOSHandler:
                 self._error_logging(f"'{file_path}' is not a file")
                 continue
             fsize = os.path.getsize(file_path)
-
-            if flatten:
-                to_upload_path = os.path.basename(file_path)
-            else:
-                to_upload_path = os.path.normpath(file_path)
-
-            if os.path.isabs(to_upload_path):
-                to_upload_path = to_upload_path.lstrip("/")
-
-            tos_target_path = os.path.normpath(
-                os.path.join(target_path, to_upload_path))
+            tos_target_path = self._resolve_upload_key(file_path, target_path,
+                                                       flatten)
 
             self._info_logging(
                 f"[{file_path}] begins to upload to [{tos_target_path}]")
@@ -177,10 +246,9 @@ class TOSHandler:
                         f"can not upload empty file {tos_target_path}")
                     _upload_fail(error_list, file_path)
                     continue
-                if fsize <= SIMPLE_UPLOAD_LIMITATION:
-                    _upload_small_file(file_path, tos_target_path)
-                else:
-                    _upload_big_file(file_path, tos_target_path, fsize)
+                self._upload_with_retry(file_path, tos_target_path, fsize,
+                                        checkpoint_dir, max_retries,
+                                        task_num)
             except Exception as err_:
                 if self._is_crc_check_error(err_):
                     self._warn_logging(f"CRC check {tos_target_path} failed, "

--- a/bioos/ops/workspace_files.py
+++ b/bioos/ops/workspace_files.py
@@ -1,7 +1,153 @@
 import os
-from typing import Optional
+from typing import Iterable, List, Optional, Union
 
 from bioos.ops.auth import login_to_bioos, resolve_workspace
+
+DEFAULT_UPLOAD_CHECKPOINT_DIR = os.path.join(
+    os.path.expanduser("~"), ".bioos", "upload-checkpoints")
+
+
+def _normalize_local_sources(sources: Union[str, Iterable[str]]) -> List[str]:
+    if isinstance(sources, str):
+        sources = [sources]
+
+    normalized_sources = []
+    for source in sources:
+        if source is None:
+            continue
+        normalized_source = os.path.normpath(os.path.expanduser(str(source)))
+        if not normalized_source:
+            continue
+        normalized_sources.append(normalized_source)
+
+    if not normalized_sources:
+        raise ValueError("At least one local source file is required.")
+    return normalized_sources
+
+
+def _resolve_workspace_upload_key(local_file_path: str,
+                                  target: str,
+                                  flatten: bool) -> str:
+    if flatten:
+        to_upload_path = os.path.basename(local_file_path)
+    else:
+        to_upload_path = os.path.normpath(local_file_path)
+
+    if os.path.isabs(to_upload_path):
+        to_upload_path = to_upload_path.lstrip("/")
+
+    return os.path.normpath(os.path.join(target, to_upload_path))
+
+
+def _upload_local_files_with_workspace(
+    ws,
+    workspace_id: str,
+    workspace_name: str,
+    sources: Union[str, Iterable[str]],
+    target: str = "",
+    flatten: bool = True,
+    skip_existing: bool = False,
+    checkpoint_dir: Optional[str] = None,
+    max_retries: int = 3,
+    task_num: int = 10,
+):
+    normalized_sources = _normalize_local_sources(sources)
+    max_retries = max(int(max_retries) if max_retries is not None else 3, 0)
+    task_num = max(int(task_num) if task_num is not None else 10, 1)
+    missing_files = [source for source in normalized_sources if not os.path.exists(source)]
+    if missing_files:
+        raise FileNotFoundError(f"Local file not found: {missing_files[0]}")
+
+    directory_sources = [source for source in normalized_sources if os.path.isdir(source)]
+    if directory_sources:
+        raise IsADirectoryError(f"Directory upload is not supported yet: {directory_sources[0]}")
+
+    resolved_checkpoint_dir = os.path.abspath(
+        os.path.expanduser(checkpoint_dir or DEFAULT_UPLOAD_CHECKPOINT_DIR))
+
+    upload_plan = []
+    for source in normalized_sources:
+        key = _resolve_workspace_upload_key(source, target, flatten)
+        upload_plan.append({
+            "source": source,
+            "key": key,
+            "s3_url": ws.files.s3_urls([key])[0],
+        })
+
+    pending_uploads = []
+    skipped_uploads = []
+    for item in upload_plan:
+        if skip_existing and ws.files.tos_handler.object_exists(item["key"]):
+            skipped_uploads.append(item)
+            continue
+        pending_uploads.append(item)
+
+    failed_sources = []
+    if pending_uploads:
+        failed_sources = ws.files.tos_handler.upload_objects(
+            files_to_upload=[item["source"] for item in pending_uploads],
+            target_path=target,
+            flatten=flatten,
+            checkpoint_dir=resolved_checkpoint_dir,
+            max_retries=max_retries,
+            task_num=task_num,
+        )
+
+    failed_source_set = set(failed_sources)
+    failed_uploads = [item for item in pending_uploads if item["source"] in failed_source_set]
+    uploaded_files = [item for item in pending_uploads if item["source"] not in failed_source_set]
+
+    if failed_uploads:
+        failed_list = ", ".join(item["source"] for item in failed_uploads)
+        raise RuntimeError(f"Failed to upload {len(failed_uploads)} file(s): {failed_list}")
+
+    return {
+        "success": True,
+        "workspace_name": workspace_name,
+        "workspace_id": workspace_id,
+        "target": target,
+        "flatten": flatten,
+        "skip_existing": skip_existing,
+        "checkpoint_dir": resolved_checkpoint_dir,
+        "max_retries": max_retries,
+        "task_num": task_num,
+        "uploaded_count": len(uploaded_files),
+        "skipped_count": len(skipped_uploads),
+        "uploaded_files": uploaded_files,
+        "skipped_files": skipped_uploads,
+    }
+
+
+def upload_local_files_to_workspace(
+    workspace_name: str,
+    sources: Union[str, Iterable[str]],
+    target: str = "",
+    flatten: bool = True,
+    skip_existing: bool = False,
+    checkpoint_dir: Optional[str] = None,
+    max_retries: int = 3,
+    task_num: int = 10,
+    access_key: Optional[str] = None,
+    secret_key: Optional[str] = None,
+    endpoint: Optional[str] = None,
+):
+    from bioos import bioos
+
+    login_to_bioos(access_key=access_key, secret_key=secret_key, endpoint=endpoint)
+    workspace_id, _ = resolve_workspace(workspace_name)
+    ws = bioos.workspace(workspace_id)
+    return _upload_local_files_with_workspace(
+        ws=ws,
+        workspace_id=workspace_id,
+        workspace_name=workspace_name,
+        sources=sources,
+        target=target,
+        flatten=flatten,
+        skip_existing=skip_existing,
+        checkpoint_dir=checkpoint_dir,
+        max_retries=max_retries,
+        task_num=task_num,
+    )
 
 
 def upload_dashboard_file_to_workspace(
@@ -11,26 +157,27 @@ def upload_dashboard_file_to_workspace(
     secret_key: Optional[str] = None,
     endpoint: Optional[str] = None,
 ):
-    from bioos import bioos
-
     if not os.path.exists(local_file_path):
         raise FileNotFoundError(f"Local file not found: {local_file_path}")
     filename = os.path.basename(local_file_path)
     if filename != "__dashboard__.md":
         raise ValueError(f"Dashboard file must be named __dashboard__.md, got: {filename}")
 
-    login_to_bioos(access_key=access_key, secret_key=secret_key, endpoint=endpoint)
-    workspace_id, _ = resolve_workspace(workspace_name)
-    ws = bioos.workspace(workspace_id)
-    success = ws.files.upload(sources=[local_file_path], target="", flatten=True)
-    if not success:
-        raise RuntimeError("Dashboard upload failed.")
-    s3_url = ws.files.s3_urls(["__dashboard__.md"])[0]
+    result = upload_local_files_to_workspace(
+        workspace_name=workspace_name,
+        sources=[local_file_path],
+        target="",
+        flatten=True,
+        access_key=access_key,
+        secret_key=secret_key,
+        endpoint=endpoint,
+    )
+    uploaded_file = result["uploaded_files"][0]
     return {
         "success": True,
         "workspace_name": workspace_name,
-        "workspace_id": workspace_id,
+        "workspace_id": result["workspace_id"],
         "local_file_path": local_file_path,
-        "s3_url": s3_url,
-        "expected_s3_url": f"s3://bioos-{workspace_id}/__dashboard__.md",
+        "s3_url": uploaded_file["s3_url"],
+        "expected_s3_url": f"s3://bioos-{result['workspace_id']}/__dashboard__.md",
     }

--- a/bioos/resource/files.py
+++ b/bioos/resource/files.py
@@ -1,4 +1,5 @@
 import datetime
+from urllib.parse import urlparse
 from typing import Iterable, List, Union
 
 import pandas as pd
@@ -208,7 +209,24 @@ class FileResource(metaclass=SingletonType):
 
         return pd.DataFrame.from_records(rows)
 
-    # TODO support s3 url input in the future
+    def _normalize_download_source(self, source: str) -> str:
+        if not isinstance(source, str):
+            raise ParameterError("sources")
+
+        if not source.startswith("s3://"):
+            return source
+
+        parsed = urlparse(source)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        if not bucket or not key:
+            raise ValueError(f"Invalid s3 source: {source}")
+        if bucket != self.bucket:
+            raise ValueError(
+                f"S3 URL bucket mismatch: expected {self.bucket}, got {bucket}"
+            )
+        return key
+
     def download(self, sources: Union[str, Iterable[str]], target: str,
                  flatten: bool) -> bool:
         """Downloads all the specified file from internal tos bucket bound to workspace to
@@ -233,15 +251,23 @@ class FileResource(metaclass=SingletonType):
         if isinstance(sources, str):
             sources = [sources]
 
+        normalized_sources = [
+            self._normalize_download_source(source)
+            for source in sources
+        ]
+
         return len(
             self.tos_handler.download_objects(  # 增加异常控制
-                sources, target, flatten)) == 0
+                normalized_sources, target, flatten)) == 0
 
     def upload(
             self,
             sources: Union[str, Iterable[str]],
             target: str,  #这里需要增加已上传的校验，如已存在同名文件，有skip的选项
-            flatten: bool) -> bool:
+            flatten: bool,
+            checkpoint_dir: str = "",
+            max_retries: int = 3,
+            task_num: int = None) -> bool:
         """Uploads a local file or a batch of local files to internal tos bucket bound to workspace.
 
         *Example*:
@@ -262,8 +288,15 @@ class FileResource(metaclass=SingletonType):
         if isinstance(sources, str):
             sources = [sources]
 
-        return len(self.tos_handler.upload_objects(sources, target,
-                                                   flatten)) == 0
+        return len(
+            self.tos_handler.upload_objects(
+                sources,
+                target,
+                flatten,
+                checkpoint_dir=checkpoint_dir,
+                max_retries=max_retries,
+                task_num=task_num if task_num is not None else 10,
+            )) == 0
 
     def delete(self, sources: Union[str, Iterable[str]]) -> bool:
         """Deletes the given file from the tos bucket bound to workspace .

--- a/bioos/resource/usage.py
+++ b/bioos/resource/usage.py
@@ -1,0 +1,130 @@
+import ast
+import json
+from typing import Iterable, Optional
+
+from bioos.config import Config
+from bioos.utils.common_tools import SingletonType
+
+
+class UsageResource(metaclass=SingletonType):
+    VALID_ASSET_TYPES = {"WorkspaceVisit", "WorkflowUse"}
+    VALID_RESOURCE_TYPES = {"cpu", "memory", "storage", "tos", "gpu"}
+
+    def get_asset_usage_data(self, start_time: int, end_time: int, type_: str):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+            "Type": self._validate_asset_type(type_),
+        }
+        return self._call_service("get_asset_usage_data", params)
+
+    def list_asset_usage(self, start_time: int, end_time: int, type_: str):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+            "Type": self._validate_asset_type(type_),
+        }
+        return self._call_service("list_asset_usage", params)
+
+    def get_total_asset_usage(self, start_time: int, end_time: int, type_: str):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+            "Type": self._validate_asset_type(type_),
+        }
+        return self._call_service("get_total_asset_usage", params)
+
+    def get_resource_usage_data(
+        self,
+        start_time: int,
+        end_time: int,
+        type_: str,
+        sub_dimensions: Optional[Iterable[str]] = None,
+    ):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+            "Type": self._validate_resource_type(type_),
+        }
+        normalized_sub_dimensions = self._normalize_sub_dimensions(sub_dimensions)
+        if normalized_sub_dimensions:
+            params["SubDimensions"] = normalized_sub_dimensions
+        return self._call_service("get_resource_usage_data", params)
+
+    def list_workspace_resource_usage(self, start_time: int, end_time: int):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+        }
+        return self._call_service("list_workspace_resource_usage", params)
+
+    def list_user_resource_usage(self, start_time: int, end_time: int):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+        }
+        return self._call_service("list_user_resource_usage", params)
+
+    def get_total_resource_usage(self, start_time: int, end_time: int):
+        params = {
+            "StartTime": self._normalize_time(start_time, "start_time"),
+            "EndTime": self._normalize_time(end_time, "end_time"),
+        }
+        return self._call_service("get_total_resource_usage", params)
+
+    def _call_service(self, method_name: str, params: dict):
+        try:
+            return getattr(Config.service(), method_name)(params)
+        except Exception as exc:
+            self._raise_friendly_usage_error(exc)
+
+    def _raise_friendly_usage_error(self, exc: Exception):
+        error_payload = self._parse_service_error(str(exc))
+        if error_payload:
+            error_code = error_payload.get("Code")
+            error_message = error_payload.get("Message", "")
+            if error_code == "ForbiddenErr" and "only account owner can access" in error_message.lower():
+                raise PermissionError(
+                    "This usage API is only available to the account owner. "
+                    "Please use the main account AK/SK instead of a sub-account key."
+                ) from exc
+        raise exc
+
+    def _parse_service_error(self, raw_message: str):
+        payload = raw_message
+        if raw_message.startswith(("b'", 'b"')):
+            try:
+                payload = ast.literal_eval(raw_message).decode("utf-8")
+            except Exception:
+                payload = raw_message
+        try:
+            data = json.loads(payload)
+        except Exception:
+            return None
+        return data.get("ResponseMetadata", {}).get("Error")
+
+    def _normalize_time(self, value: int, name: str) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be an integer timestamp.") from exc
+
+    def _validate_asset_type(self, type_: str) -> str:
+        if type_ not in self.VALID_ASSET_TYPES:
+            allowed = ", ".join(sorted(self.VALID_ASSET_TYPES))
+            raise ValueError(f"Invalid asset usage type: {type_}. Allowed values: {allowed}.")
+        return type_
+
+    def _validate_resource_type(self, type_: str) -> str:
+        if type_ not in self.VALID_RESOURCE_TYPES:
+            allowed = ", ".join(sorted(self.VALID_RESOURCE_TYPES))
+            raise ValueError(f"Invalid resource usage type: {type_}. Allowed values: {allowed}.")
+        return type_
+
+    def _normalize_sub_dimensions(self, values: Optional[Iterable[str]]):
+        if values is None:
+            return None
+        if isinstance(values, str):
+            values = [values]
+        normalized = [str(value).strip() for value in values if str(value).strip()]
+        return normalized or None

--- a/bioos/resource/workspaces.py
+++ b/bioos/resource/workspaces.py
@@ -15,6 +15,7 @@ from bioos.utils.common_tools import SingletonType, dict_str
 
 
 class Workspace(metaclass=SingletonType):
+    VALID_MEMBER_ROLES = {"Visitor", "User", "Admin"}
 
     def __init__(self, id_: str):
         self._id = id_
@@ -149,6 +150,79 @@ class Workspace(metaclass=SingletonType):
         """把当前 Workspace 绑定到指定集群"""
         params = {"ClusterID": cluster_id, "Type": type_, "ID": self._id}
         return Config.service().bind_cluster_to_workspace(params)
+
+    def list_members(self,
+                     filter_: dict = None,
+                     page_number: int = None,
+                     page_size: int = None,
+                     in_workspace: bool = True,
+                     roles=None,
+                     keyword: str = None):
+        resolved_filter = {"InWorkspace": bool(in_workspace)}
+        if filter_:
+            resolved_filter.update(filter_)
+
+        normalized_roles = self._normalize_member_names(roles)
+        if normalized_roles is not None:
+            resolved_filter["Roles"] = normalized_roles
+        if keyword is not None and str(keyword).strip():
+            resolved_filter["Keyword"] = str(keyword).strip()
+
+        params = {
+            "WorkspaceID": self._id,
+            "Filter": resolved_filter,
+        }
+        if page_number is not None:
+            params["PageNumber"] = int(page_number)
+        if page_size is not None:
+            params["PageSize"] = int(page_size)
+        return Config.service().list_members(params)
+
+    def add_members(self, names=None, role: str = ""):
+        params = {
+            "WorkspaceID": self._id,
+            "Role": self._validate_member_role(role),
+        }
+        normalized_names = self._normalize_member_names(names)
+        if normalized_names is not None:
+            params["Names"] = normalized_names
+        return Config.service().add_members(params)
+
+    def delete_members(self, names=None):
+        params = {"WorkspaceID": self._id}
+        normalized_names = self._normalize_member_names(names)
+        if normalized_names is not None:
+            params["Names"] = normalized_names
+        return Config.service().delete_members(params)
+
+    def update_members(self, names, role: str):
+        normalized_names = self._normalize_member_names(names, required=True)
+        params = {
+            "WorkspaceID": self._id,
+            "Names": normalized_names,
+            "Role": self._validate_member_role(role),
+        }
+        return Config.service().update_members(params)
+
+    def _validate_member_role(self, role: str) -> str:
+        if role not in self.VALID_MEMBER_ROLES:
+            allowed_roles = ", ".join(sorted(self.VALID_MEMBER_ROLES))
+            raise ValueError(f"Invalid member role: {role}. Allowed roles: {allowed_roles}.")
+        return role
+
+    def _normalize_member_names(self, names, required: bool = False):
+        if names is None:
+            if required:
+                raise ValueError("At least one member name is required.")
+            return None
+
+        if isinstance(names, str):
+            names = [names]
+
+        normalized_names = [str(name).strip() for name in names if str(name).strip()]
+        if required and not normalized_names:
+            raise ValueError("At least one member name is required.")
+        return normalized_names or None
 
 
     def export_workspace_v2(self, 

--- a/bioos/service/BioOsService.py
+++ b/bioos/service/BioOsService.py
@@ -52,6 +52,61 @@ class BioOsService(Service):
                 'Action': 'CreateWorkspace',
                 'Version': '2021-03-04'
             }, {}, {}),
+            'AddMembers':
+            ApiInfo('POST', '/', {
+                'Action': 'AddMembers',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'ListMembers':
+            ApiInfo('POST', '/', {
+                'Action': 'ListMembers',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'DeleteMembers':
+            ApiInfo('POST', '/', {
+                'Action': 'DeleteMembers',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'UpdateMembers':
+            ApiInfo('POST', '/', {
+                'Action': 'UpdateMembers',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'GetAssetUsageData':
+            ApiInfo('POST', '/', {
+                'Action': 'GetAssetUsageData',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'ListAssetUsage':
+            ApiInfo('POST', '/', {
+                'Action': 'ListAssetUsage',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'GetTotalAssetUsage':
+            ApiInfo('POST', '/', {
+                'Action': 'GetTotalAssetUsage',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'GetResourceUsageData':
+            ApiInfo('POST', '/', {
+                'Action': 'GetResourceUsageData',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'ListWorkspaceResourceUsage':
+            ApiInfo('POST', '/', {
+                'Action': 'ListWorkspaceResourceUsage',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'ListUserResourceUsage':
+            ApiInfo('POST', '/', {
+                'Action': 'ListUserResourceUsage',
+                'Version': '2021-03-04'
+            }, {}, {}),
+            'GetTotalResourceUsage':
+            ApiInfo('POST', '/', {
+                'Action': 'GetTotalResourceUsage',
+                'Version': '2021-03-04'
+            }, {}, {}),
             'CreateDataModel':
             ApiInfo('POST', '/', {
                 'Action': 'CreateDataModel',
@@ -200,6 +255,40 @@ class BioOsService(Service):
 
     def create_workspace(self, params):
         return self.__request('CreateWorkspace', params)
+
+    def add_members(self, params):
+        return self.__request('AddMembers', params)
+
+    def list_members(self, params):
+        return self.__request('ListMembers', params)
+
+    def delete_members(self, params):
+        return self.__request('DeleteMembers', params)
+
+    def update_members(self, params):
+        return self.__request('UpdateMembers', params)
+
+    def get_asset_usage_data(self, params):
+        return self.__request('GetAssetUsageData', params)
+
+    def list_asset_usage(self, params):
+        return self.__request('ListAssetUsage', params)
+
+    def get_total_asset_usage(self, params):
+        return self.__request('GetTotalAssetUsage', params)
+
+    def get_resource_usage_data(self, params):
+        return self.__request('GetResourceUsageData', params)
+
+    def list_workspace_resource_usage(self, params):
+        return self.__request('ListWorkspaceResourceUsage', params)
+
+    def list_user_resource_usage(self, params):
+        return self.__request('ListUserResourceUsage', params)
+
+    def get_total_resource_usage(self, params):
+        return self.__request('GetTotalResourceUsage', params)
+
     def create_data_model(self, params):
         return self.__request('CreateDataModel', params)
 

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -6,11 +7,13 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from bioos.cli import (
+    add_workspace_members,
     build_docker_image,
     check_build_status,
     check_ies_status,
     create_iesapp,
     create_workspace_bioos,
+    delete_workspace_members,
     delete_submission,
     download_files_from_workspace,
     export_bioos_workspace,
@@ -21,11 +24,15 @@ from bioos.cli import (
     get_workspace_profile,
     list_bioos_workspaces,
     list_files_from_workspace,
+    list_workspace_members,
     list_submissions_from_workspace,
     list_workflows_from_workspace,
     main as cli_main,
     search_dockstore,
     upload_dashboard_file,
+    upload_files_to_workspace,
+    usage_metrics,
+    update_workspace_members,
     validate_wdl,
 )
 from bioos import bioos_workflow, bw_import, bw_import_status_check, bw_status_check, get_submission_logs as submission_logs_module
@@ -116,6 +123,37 @@ class TestCliHandlers(unittest.TestCase):
             result = download_files_from_workspace.handle(args)
         ws.files.download.assert_called_once_with(sources=["a.txt", "b.txt"], target="/tmp/out", flatten=True)
         self.assertTrue(result["success"])
+
+    def test_upload_files_to_workspace_handle(self):
+        args = SimpleNamespace(
+            workspace_name="ws",
+            source=["a.txt", "b.txt"],
+            target="input_provision/",
+            flatten=True,
+            skip_existing=True,
+            checkpoint_dir="/tmp/ckpt",
+            max_retries=5,
+            task_num=8,
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        with patch("bioos.cli.upload_files_to_workspace.upload_local_files_to_workspace", return_value={"success": True}) as mocked:
+            result = upload_files_to_workspace.handle(args)
+        self.assertEqual(result, {"success": True})
+        mocked.assert_called_once_with(
+            workspace_name="ws",
+            sources=["a.txt", "b.txt"],
+            target="input_provision/",
+            flatten=True,
+            skip_existing=True,
+            checkpoint_dir="/tmp/ckpt",
+            max_retries=5,
+            task_num=8,
+            access_key="ak",
+            secret_key="sk",
+            endpoint="ep",
+        )
 
     def test_create_iesapp_handle(self):
         args = SimpleNamespace(
@@ -216,6 +254,75 @@ class TestCliHandlers(unittest.TestCase):
             result = upload_dashboard_file.handle(args)
         self.assertEqual(result, {"success": True})
         mocked.assert_called_once()
+
+    def test_list_workspace_members_handle(self):
+        args = SimpleNamespace(
+            workspace_name="ws",
+            page_number=2,
+            page_size=50,
+            in_workspace=True,
+            role=["Admin"],
+            keyword="alice",
+        )
+        ws = MagicMock()
+        ws.list_members.return_value = [{"Name": "alice", "Role": "Admin"}]
+        with patch("bioos.cli.list_workspace_members.workspace_context_from_args", return_value=("wid", ws)):
+            result = list_workspace_members.handle(args)
+        ws.list_members.assert_called_once_with(
+            page_number=2,
+            page_size=50,
+            in_workspace=True,
+            roles=["Admin"],
+            keyword="alice",
+        )
+        self.assertEqual(result["members"], [{"Name": "alice", "Role": "Admin"}])
+
+    def test_add_workspace_members_handle(self):
+        args = SimpleNamespace(workspace_name="ws", name=["alice", "bob"], role="User")
+        ws = MagicMock()
+        ws.add_members.return_value = {"updated": 2}
+        with patch("bioos.cli.add_workspace_members.workspace_context_from_args", return_value=("wid", ws)):
+            result = add_workspace_members.handle(args)
+        ws.add_members.assert_called_once_with(names=["alice", "bob"], role="User")
+        self.assertEqual(result["result"], {"updated": 2})
+
+    def test_update_workspace_members_handle(self):
+        args = SimpleNamespace(workspace_name="ws", name=["alice"], role="Admin")
+        ws = MagicMock()
+        ws.update_members.return_value = {"updated": 1}
+        with patch("bioos.cli.update_workspace_members.workspace_context_from_args", return_value=("wid", ws)):
+            result = update_workspace_members.handle(args)
+        ws.update_members.assert_called_once_with(names=["alice"], role="Admin")
+        self.assertEqual(result["result"], {"updated": 1})
+
+    def test_delete_workspace_members_handle(self):
+        args = SimpleNamespace(workspace_name="ws", name=["alice"])
+        ws = MagicMock()
+        ws.delete_members.return_value = {"deleted": 1}
+        with patch("bioos.cli.delete_workspace_members.workspace_context_from_args", return_value=("wid", ws)):
+            result = delete_workspace_members.handle(args)
+        ws.delete_members.assert_called_once_with(names=["alice"])
+        self.assertEqual(result["result"], {"deleted": 1})
+
+    def test_usage_asset_usage_data_handle(self):
+        args = SimpleNamespace(start_time=1, end_time=2, type="WorkspaceVisit", ak="ak", sk="sk", endpoint="ep")
+        usage = MagicMock()
+        usage.get_asset_usage_data.return_value = {"Items": []}
+        with patch("bioos.cli.usage_metrics.login_with_args"), \
+                patch("bioos.bioos.usage", return_value=usage):
+            result = usage_metrics.handle_asset_usage_data(args)
+        usage.get_asset_usage_data.assert_called_once_with(1, 2, "WorkspaceVisit")
+        self.assertEqual(result["result"], {"Items": []})
+
+    def test_usage_user_resource_usage_handle(self):
+        args = SimpleNamespace(start_time=1, end_time=2, ak="ak", sk="sk", endpoint="ep")
+        usage = MagicMock()
+        usage.list_user_resource_usage.return_value = {"Items": []}
+        with patch("bioos.cli.usage_metrics.login_with_args"), \
+                patch("bioos.bioos.usage", return_value=usage):
+            result = usage_metrics.handle_user_resource_usage(args)
+        usage.list_user_resource_usage.assert_called_once_with(1, 2)
+        self.assertEqual(result["result"], {"Items": []})
 
     def test_search_dockstore_handle(self):
         args = SimpleNamespace(
@@ -392,6 +499,116 @@ class TestCliRootAndAuth(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         mocked.assert_called_once()
 
+    def test_root_workspace_member_list_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.list_workspace_members.handle", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                ["workspace", "member", "list", "--workspace-name", "ws", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_workspace_member_add_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.add_workspace_members.handle", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "workspace",
+                    "member",
+                    "add",
+                    "--workspace-name",
+                    "ws",
+                    "--name",
+                    "alice",
+                    "--role",
+                    "User",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_workspace_member_update_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.update_workspace_members.handle", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "workspace",
+                    "member",
+                    "update",
+                    "--workspace-name",
+                    "ws",
+                    "--name",
+                    "alice",
+                    "--role",
+                    "Admin",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_workspace_member_delete_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.delete_workspace_members.handle", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "workspace",
+                    "member",
+                    "delete",
+                    "--workspace-name",
+                    "ws",
+                    "--name",
+                    "alice",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_usage_asset_data_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.usage_metrics.handle_asset_usage_data", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                ["usage", "asset-data", "--start-time", "1", "--end-time", "2", "--type", "WorkspaceVisit", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_usage_resource_user_list_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.usage_metrics.handle_user_resource_usage", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                ["usage", "resource-user-list", "--start-time", "1", "--end-time", "2", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_file_upload_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.upload_files_to_workspace.handle", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "file",
+                    "upload",
+                    "--workspace-name",
+                    "ws",
+                    "--source",
+                    "a.txt",
+                    "--checkpoint-dir",
+                    "/tmp/ckpt",
+                    "--max-retries",
+                    "5",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
     def test_root_config_path_returns_success(self):
         exit_code = cli_main.main(["config", "path", "--output", "json"])
         self.assertEqual(exit_code, 0)
@@ -533,6 +750,372 @@ class TestCliRootAndAuth(unittest.TestCase):
 
         login_mock.assert_called_once()
         self.assertIn("Submission ID: sub1", result)
+
+    def test_preprocess2_uses_workspace_upload_helper(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_json = Path(tmpdir) / "inputs.json"
+            local_file = Path(tmpdir) / "sample.txt"
+            local_file.write_text("data", encoding="utf-8")
+            input_json.write_text(
+                '{"wf.input":"' + str(local_file) + '","wf.name":"sample"}',
+                encoding="utf-8",
+            )
+
+            class FakeSeries:
+                def __len__(self):
+                    return 1
+
+                def to_list(self):
+                    return ["wid"]
+
+            class FakeWorkspaces:
+                Name = "ws"
+                ID = FakeSeries()
+
+                def __getitem__(self, key):
+                    return self
+
+            with patch("bioos.bioos_workflow.bioos.list_workspaces") as list_mock, \
+                    patch("bioos.bioos_workflow.bioos.workspace") as workspace_mock, \
+                    patch("bioos.bioos_workflow._upload_local_files_with_workspace") as upload_mock:
+                list_mock.return_value = FakeWorkspaces()
+
+                ws = MagicMock()
+                workspace_mock.return_value = ws
+                bw = bioos_workflow.Bioos_workflow(workspace_name="ws", workflow_name="wf")
+                upload_mock.return_value = {
+                    "uploaded_files": [{
+                        "source": str(local_file),
+                        "key": "input_provision/sample.txt",
+                        "s3_url": "s3://bioos-wid/input_provision/sample.txt",
+                    }],
+                    "skipped_files": [],
+                }
+
+                result = bw.preprocess2(
+                    input_json_file=str(input_json),
+                    data_model_name="dm",
+                    submission_desc="desc",
+                    call_caching=True,
+                    force_reupload=False,
+                    mount_tos=False,
+                )
+
+        upload_mock.assert_called_once()
+        self.assertIn("s3://bioos-wid/input_provision/sample.txt", result["inputs"])
+
+    def test_dataframe_map_compat_falls_back_to_applymap(self):
+        class FakeDataFrame:
+            def __init__(self):
+                self.called = None
+
+            def applymap(self, func):
+                self.called = ("applymap", func("x"))
+                return "applymap-result"
+
+        fake_df = FakeDataFrame()
+        result = bioos_workflow.dataframe_map_compat(fake_df, str)
+        self.assertEqual(result, "applymap-result")
+        self.assertEqual(fake_df.called, ("applymap", "x"))
+
+    def test_preprocess2_replaces_chinese_local_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chinese_dir = Path(tmpdir) / "广实上交模型"
+            chinese_dir.mkdir()
+            local_file = chinese_dir / "data.xlsx"
+            local_file.write_text("data", encoding="utf-8")
+            input_json = Path(tmpdir) / "inputs.json"
+            input_json.write_text(
+                json.dumps({
+                    "wf.input_excel": str(local_file),
+                    "wf.region": "north",
+                }, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            class FakeSeries:
+                def __len__(self):
+                    return 1
+
+                def to_list(self):
+                    return ["wid"]
+
+            class FakeWorkspaces:
+                Name = "ws"
+                ID = FakeSeries()
+
+                def __getitem__(self, key):
+                    return self
+
+            with patch("bioos.bioos_workflow.bioos.list_workspaces", return_value=FakeWorkspaces()), \
+                    patch("bioos.bioos_workflow.bioos.workspace", return_value=MagicMock()), \
+                    patch("bioos.bioos_workflow._upload_local_files_with_workspace") as upload_mock:
+                upload_mock.return_value = {
+                    "uploaded_files": [{
+                        "source": str(local_file),
+                        "key": "input_provision/data.xlsx",
+                        "s3_url": "s3://bioos-wid/input_provision/data.xlsx",
+                    }],
+                    "skipped_files": [],
+                }
+                bw = bioos_workflow.Bioos_workflow(workspace_name="ws", workflow_name="wf")
+                result = bw.preprocess2(
+                    input_json_file=str(input_json),
+                    data_model_name="dm",
+                    submission_desc="desc",
+                    call_caching=True,
+                    force_reupload=False,
+                    mount_tos=False,
+                )
+
+        upload_mock.assert_called_once()
+        self.assertIn("s3://bioos-wid/input_provision/data.xlsx", result["inputs"])
+
+    def test_preprocess2_batch_replaces_multiple_local_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_a = Path(tmpdir) / "a.txt"
+            file_b = Path(tmpdir) / "b.txt"
+            file_a.write_text("a", encoding="utf-8")
+            file_b.write_text("b", encoding="utf-8")
+            input_json = Path(tmpdir) / "inputs.json"
+            input_json.write_text(
+                json.dumps([
+                    {"wf.input": str(file_a), "wf.region": "north"},
+                    {"wf.input": str(file_b), "wf.region": "south"},
+                ], ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            class FakeSeries:
+                def __len__(self):
+                    return 1
+
+                def to_list(self):
+                    return ["wid"]
+
+            class FakeWorkspaces:
+                Name = "ws"
+                ID = FakeSeries()
+
+                def __getitem__(self, key):
+                    return self
+
+            ws = MagicMock()
+            ws.data_models.write = MagicMock()
+            with patch("bioos.bioos_workflow.bioos.list_workspaces", return_value=FakeWorkspaces()), \
+                    patch("bioos.bioos_workflow.bioos.workspace", return_value=ws), \
+                    patch("bioos.bioos_workflow._upload_local_files_with_workspace") as upload_mock:
+                upload_mock.return_value = {
+                    "uploaded_files": [
+                        {
+                            "source": str(file_a),
+                            "key": "input_provision/a.txt",
+                            "s3_url": "s3://bioos-wid/input_provision/a.txt",
+                        },
+                        {
+                            "source": str(file_b),
+                            "key": "input_provision/b.txt",
+                            "s3_url": "s3://bioos-wid/input_provision/b.txt",
+                        },
+                    ],
+                    "skipped_files": [],
+                }
+                bw = bioos_workflow.Bioos_workflow(workspace_name="ws", workflow_name="wf")
+                result = bw.preprocess2(
+                    input_json_file=str(input_json),
+                    data_model_name="batch_dm",
+                    submission_desc="desc",
+                    call_caching=True,
+                    force_reupload=False,
+                    mount_tos=False,
+                )
+
+        upload_mock.assert_called_once()
+        written_payload = ws.data_models.write.call_args.args[0]
+        written_df = written_payload["batch_dm"]
+        self.assertIn("s3://bioos-wid/input_provision/a.txt", written_df["input"].tolist())
+        self.assertIn("s3://bioos-wid/input_provision/b.txt", written_df["input"].tolist())
+        self.assertIn('"this.input"', result["inputs"])
+        self.assertEqual(result["data_model_name"], "batch_dm")
+        self.assertEqual(len(result["row_ids"]), 2)
+
+    def test_preprocess2_without_local_files_skips_upload_helper(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_json = Path(tmpdir) / "inputs.json"
+            input_json.write_text(
+                json.dumps({"wf.input": "drs://bucket/object", "wf.region": "north"}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            class FakeSeries:
+                def __len__(self):
+                    return 1
+
+                def to_list(self):
+                    return ["wid"]
+
+            class FakeWorkspaces:
+                Name = "ws"
+                ID = FakeSeries()
+
+                def __getitem__(self, key):
+                    return self
+
+            with patch("bioos.bioos_workflow.bioos.list_workspaces", return_value=FakeWorkspaces()), \
+                    patch("bioos.bioos_workflow.bioos.workspace", return_value=MagicMock()), \
+                    patch("bioos.bioos_workflow._upload_local_files_with_workspace") as upload_mock:
+                bw = bioos_workflow.Bioos_workflow(workspace_name="ws", workflow_name="wf")
+                result = bw.preprocess2(
+                    input_json_file=str(input_json),
+                    data_model_name="dm",
+                    submission_desc="desc",
+                    call_caching=True,
+                    force_reupload=False,
+                    mount_tos=False,
+                )
+
+        upload_mock.assert_not_called()
+        self.assertIn("drs://bucket/object", result["inputs"])
+
+    def test_preprocess2_force_reupload_disables_skip_existing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_file = Path(tmpdir) / "sample.txt"
+            local_file.write_text("x", encoding="utf-8")
+            input_json = Path(tmpdir) / "inputs.json"
+            input_json.write_text(
+                json.dumps({"wf.input": str(local_file)}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            class FakeSeries:
+                def __len__(self):
+                    return 1
+
+                def to_list(self):
+                    return ["wid"]
+
+            class FakeWorkspaces:
+                Name = "ws"
+                ID = FakeSeries()
+
+                def __getitem__(self, key):
+                    return self
+
+            with patch("bioos.bioos_workflow.bioos.list_workspaces", return_value=FakeWorkspaces()), \
+                    patch("bioos.bioos_workflow.bioos.workspace", return_value=MagicMock()), \
+                    patch("bioos.bioos_workflow._upload_local_files_with_workspace") as upload_mock:
+                upload_mock.return_value = {
+                    "uploaded_files": [{
+                        "source": str(local_file),
+                        "key": "input_provision/sample.txt",
+                        "s3_url": "s3://bioos-wid/input_provision/sample.txt",
+                    }],
+                    "skipped_files": [],
+                }
+                bw = bioos_workflow.Bioos_workflow(workspace_name="ws", workflow_name="wf")
+                bw.preprocess2(
+                    input_json_file=str(input_json),
+                    data_model_name="dm",
+                    submission_desc="desc",
+                    call_caching=True,
+                    force_reupload=True,
+                    mount_tos=False,
+                )
+
+        self.assertFalse(upload_mock.call_args.kwargs["skip_existing"])
+
+    def test_collect_local_file_paths_recursively_filters_and_deduplicates(self):
+        existing_paths = {
+            "/tmp/project/广实上交模型/data.xlsx",
+            "/tmp/project/with space/report final.csv",
+            "/tmp/project/a.txt",
+        }
+        payload = {
+            "single": "/tmp/project/a.txt",
+            "nested": {
+                "batch": [
+                    "/tmp/project/广实上交模型/data.xlsx",
+                    "s3://bucket/already-uploaded.txt",
+                    "registry-vpc://image",
+                    "/tmp/project/missing.txt",
+                    {
+                        "again": "/tmp/project/a.txt",
+                        "with_space": "/tmp/project/with space/report final.csv",
+                    },
+                ]
+            },
+            "number": 123,
+            "boolean": True,
+            "none": None,
+        }
+
+        with patch("bioos.bioos_workflow.os.path.isfile", side_effect=lambda value: value in existing_paths):
+            result = bioos_workflow.collect_local_file_paths(payload)
+
+        self.assertEqual(
+            result,
+            {
+                "/tmp/project/a.txt",
+                "/tmp/project/广实上交模型/data.xlsx",
+                "/tmp/project/with space/report final.csv",
+            },
+        )
+
+    def test_collect_local_file_paths_supports_batch_input_list(self):
+        existing_paths = {
+            "/tmp/batch/a.fastq.gz",
+            "/tmp/batch/b.fastq.gz",
+        }
+        payload = [
+            {"wf.input": "/tmp/batch/a.fastq.gz", "wf.region": "north"},
+            {"wf.input": "/tmp/batch/b.fastq.gz", "wf.region": "south"},
+            {"wf.input": "drs://archive/object", "wf.region": "west"},
+        ]
+
+        with patch("bioos.bioos_workflow.os.path.isfile", side_effect=lambda value: value in existing_paths):
+            result = bioos_workflow.collect_local_file_paths(payload)
+
+        self.assertEqual(
+            result,
+            {
+                "/tmp/batch/a.fastq.gz",
+                "/tmp/batch/b.fastq.gz",
+            },
+        )
+
+    def test_replace_local_paths_with_s3_recursively_rewrites_exact_matches(self):
+        payload = {
+            "wf.input": "/tmp/project/a.txt",
+            "nested": [
+                "/tmp/project/广实上交模型/data.xlsx",
+                {
+                    "keep": "drs://archive/object",
+                    "replace": "/tmp/project/a.txt",
+                },
+            ],
+            "message": "prefix /tmp/project/a.txt should not be partially replaced inside longer text",
+        }
+        source_to_s3 = {
+            "/tmp/project/a.txt": "s3://bioos-wid/input_provision/a.txt",
+            "/tmp/project/广实上交模型/data.xlsx": "s3://bioos-wid/input_provision/data.xlsx",
+        }
+
+        result = bioos_workflow.replace_local_paths_with_s3(payload, source_to_s3)
+
+        self.assertEqual(
+            result,
+            {
+                "wf.input": "s3://bioos-wid/input_provision/a.txt",
+                "nested": [
+                    "s3://bioos-wid/input_provision/data.xlsx",
+                    {
+                        "keep": "drs://archive/object",
+                        "replace": "s3://bioos-wid/input_provision/a.txt",
+                    },
+                ],
+                "message": "prefix /tmp/project/a.txt should not be partially replaced inside longer text",
+            },
+        )
 
     def test_legacy_workflow_submit_entrypoint_exits_cleanly(self):
         parser = MagicMock()

--- a/tests/test_ops_unit.py
+++ b/tests/test_ops_unit.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from bioos.ops import docker_build, dockstore, womtool, workspace_files
+from bioos.internal.tos import TOSHandler
+from bioos.resource.files import FileResource
+from bioos.resource.usage import UsageResource
+from bioos.resource.workspaces import Workspace
 
 
 class TestOpsHelpers(unittest.TestCase):
@@ -114,14 +118,243 @@ class TestOpsHelpers(unittest.TestCase):
             dashboard = Path(tmpdir) / "__dashboard__.md"
             dashboard.write_text("# dashboard", encoding="utf-8")
             ws = MagicMock()
-            ws.files.upload.return_value = True
             ws.files.s3_urls.return_value = ["s3://bioos-wid/__dashboard__.md"]
+            ws.files.tos_handler.object_exists.return_value = False
+            ws.files.tos_handler.upload_objects.return_value = []
             with patch("bioos.ops.workspace_files.login_to_bioos"), \
                     patch("bioos.ops.workspace_files.resolve_workspace", return_value=("wid", {})), \
                     patch("bioos.bioos.workspace", return_value=ws):
                 result = workspace_files.upload_dashboard_file_to_workspace("ws", str(dashboard), "ak", "sk", "ep")
         self.assertTrue(result["success"])
         self.assertEqual(result["workspace_id"], "wid")
+
+    def test_upload_local_files_to_workspace(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_a = Path(tmpdir) / "a.txt"
+            local_b = Path(tmpdir) / "b.txt"
+            local_a.write_text("a", encoding="utf-8")
+            local_b.write_text("b", encoding="utf-8")
+            ws = MagicMock()
+            ws.files.s3_urls.side_effect = lambda keys: [f"s3://bioos-wid/{keys[0]}"]
+            ws.files.tos_handler.object_exists.side_effect = [True, False]
+            ws.files.tos_handler.upload_objects.return_value = []
+
+            with patch("bioos.ops.workspace_files.login_to_bioos"), \
+                    patch("bioos.ops.workspace_files.resolve_workspace", return_value=("wid", {})), \
+                    patch("bioos.bioos.workspace", return_value=ws):
+                result = workspace_files.upload_local_files_to_workspace(
+                    workspace_name="ws",
+                    sources=[str(local_a), str(local_b)],
+                    target="input_provision/",
+                    flatten=True,
+                    skip_existing=True,
+                    checkpoint_dir=str(Path(tmpdir) / "checkpoints"),
+                    max_retries=5,
+                    task_num=8,
+                    access_key="ak",
+                    secret_key="sk",
+                    endpoint="ep",
+                )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["workspace_id"], "wid")
+        self.assertEqual(result["uploaded_count"], 1)
+        self.assertEqual(result["skipped_count"], 1)
+        ws.files.tos_handler.upload_objects.assert_called_once_with(
+            files_to_upload=[str(local_b)],
+            target_path="input_provision/",
+            flatten=True,
+            checkpoint_dir=str(Path(tmpdir) / "checkpoints"),
+            max_retries=5,
+            task_num=8,
+        )
+
+    def test_upload_local_files_with_workspace(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_a = Path(tmpdir) / "a.txt"
+            local_a.write_text("a", encoding="utf-8")
+            ws = MagicMock()
+            ws.files.s3_urls.side_effect = lambda keys: [f"s3://bioos-wid/{keys[0]}"]
+            ws.files.tos_handler.object_exists.return_value = False
+            ws.files.tos_handler.upload_objects.return_value = []
+
+            result = workspace_files._upload_local_files_with_workspace(
+                ws=ws,
+                workspace_id="wid",
+                workspace_name="ws",
+                sources=[str(local_a)],
+                target="input_provision/",
+                flatten=True,
+                skip_existing=False,
+                checkpoint_dir=str(Path(tmpdir) / "checkpoints"),
+                max_retries=2,
+                task_num=4,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["uploaded_count"], 1)
+        ws.files.tos_handler.upload_objects.assert_called_once()
+
+    def test_tos_handler_upload_objects_uses_checkpoint_and_retries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_file = Path(tmpdir) / "large.bin"
+            local_file.write_text("placeholder", encoding="utf-8")
+            checkpoint_dir = Path(tmpdir) / "ckpt"
+            client = MagicMock()
+            client.upload_file.side_effect = [Exception("temporary"), None]
+            handler = TOSHandler(client=client, bucket="bucket")
+
+            with patch("bioos.internal.tos.os.path.getsize", return_value=1024 * 1024 * 101):
+                failed = handler.upload_objects(
+                    [str(local_file)],
+                    "target",
+                    flatten=True,
+                    checkpoint_dir=str(checkpoint_dir),
+                    max_retries=2,
+                    task_num=4,
+                )
+
+        self.assertEqual(failed, [])
+        self.assertEqual(client.upload_file.call_count, 2)
+        first_call = client.upload_file.call_args_list[0].kwargs
+        self.assertEqual(first_call["bucket"], "bucket")
+        self.assertEqual(first_call["key"], "target/large.bin")
+        self.assertEqual(first_call["task_num"], 4)
+        self.assertTrue(first_call["enable_checkpoint"])
+        self.assertTrue(first_call["checkpoint_file"].endswith(".upload.ckpt"))
+
+    def test_file_resource_download_accepts_workspace_s3_url(self):
+        resource = FileResource.__new__(FileResource)
+        resource.bucket = "bioos-wid"
+        resource.tos_handler = MagicMock()
+        resource.tos_handler.download_objects.return_value = []
+
+        success = resource.download(
+            sources="s3://bioos-wid/input_provision/a.txt",
+            target="/tmp/out",
+            flatten=False,
+        )
+
+        self.assertTrue(success)
+        resource.tos_handler.download_objects.assert_called_once_with(
+            ["input_provision/a.txt"],
+            "/tmp/out",
+            False,
+        )
+
+    def test_file_resource_download_rejects_other_workspace_s3_url(self):
+        resource = FileResource.__new__(FileResource)
+        resource.bucket = "bioos-wid"
+        resource.tos_handler = MagicMock()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "S3 URL bucket mismatch: expected bioos-wid, got bioos-other",
+        ):
+            resource.download(
+                sources="s3://bioos-other/input_provision/a.txt",
+                target="/tmp/out",
+                flatten=False,
+            )
+
+    def test_file_resource_download_accepts_internal_key(self):
+        resource = FileResource.__new__(FileResource)
+        resource.bucket = "bioos-wid"
+        resource.tos_handler = MagicMock()
+        resource.tos_handler.download_objects.return_value = []
+
+        success = resource.download(
+            sources="input_provision/a.txt",
+            target="/tmp/out",
+            flatten=True,
+        )
+
+        self.assertTrue(success)
+        resource.tos_handler.download_objects.assert_called_once_with(
+            ["input_provision/a.txt"],
+            "/tmp/out",
+            True,
+        )
+
+    def test_usage_resource_rejects_invalid_asset_type(self):
+        usage = UsageResource.__new__(UsageResource)
+        with self.assertRaisesRegex(ValueError, "Invalid asset usage type"):
+            usage.get_asset_usage_data(1, 2, "BadType")
+
+    def test_usage_resource_rejects_invalid_resource_type(self):
+        usage = UsageResource.__new__(UsageResource)
+        with self.assertRaisesRegex(ValueError, "Invalid resource usage type"):
+            usage.get_resource_usage_data(1, 2, "BadType")
+
+    def test_usage_resource_translates_account_owner_permission_error(self):
+        usage = UsageResource.__new__(UsageResource)
+        with patch("bioos.resource.usage.Config.service") as service_mock:
+            service_mock.return_value.list_user_resource_usage.side_effect = Exception(
+                "b'{\"ResponseMetadata\":{\"Error\":{\"Code\":\"ForbiddenErr\",\"Message\":\"only account owner can access\"}}}'"
+            )
+            with self.assertRaisesRegex(
+                PermissionError,
+                "This usage API is only available to the account owner",
+            ):
+                usage.list_user_resource_usage(1, 2)
+
+    def test_workspace_list_members_defaults_to_in_workspace_filter(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "wid"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_members.return_value = {"Items": []}
+            result = workspace.list_members()
+
+        self.assertEqual(result, {"Items": []})
+        service_mock.return_value.list_members.assert_called_once_with(
+            {
+                "WorkspaceID": "wid",
+                "Filter": {"InWorkspace": True},
+            }
+        )
+
+    def test_workspace_list_members_supports_pagination(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "wid"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_members.return_value = {"Items": []}
+            result = workspace.list_members(page_number=2, page_size=50)
+
+        self.assertEqual(result, {"Items": []})
+        service_mock.return_value.list_members.assert_called_once_with(
+            {
+                "WorkspaceID": "wid",
+                "Filter": {"InWorkspace": True},
+                "PageNumber": 2,
+                "PageSize": 50,
+            }
+        )
+
+    def test_workspace_list_members_supports_filters(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "wid"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_members.return_value = {"Items": []}
+            result = workspace.list_members(
+                in_workspace=False,
+                roles=["Admin", "User"],
+                keyword="alice",
+            )
+
+        self.assertEqual(result, {"Items": []})
+        service_mock.return_value.list_members.assert_called_once_with(
+            {
+                "WorkspaceID": "wid",
+                "Filter": {
+                    "InWorkspace": False,
+                    "Roles": ["Admin", "User"],
+                    "Keyword": "alice",
+                },
+            }
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR expands the unified `bioos` CLI and related SDK layers in several areas:

1. Add a resilient workspace file upload flow with multipart resume and retry support
2. Improve workflow local-file preprocessing before submission
3. Add workspace member management commands
4. Add account-level usage query commands
5. Improve file download support for current-workspace `s3://...` paths

In addition to the new features, this PR also fixes a few existing issues in file preprocessing and download behavior.

## Main Changes

### 1. Resilient file upload

Added a new `bioos file upload` command for uploading one or more local files into a workspace bucket.

Supported capabilities:
- multiple `--source` inputs
- multipart upload for large files
- checkpoint-based resume
- per-file retry
- `--skip-existing`
- configurable multipart task count

Implementation highlights:
- shared upload orchestration added under `bioos.ops.workspace_files`
- retry/checkpoint handling added in `bioos.internal.tos`
- `FileResource.upload(...)` extended to pass through upload reliability parameters

### 2. Workflow local-file preprocessing improvement

`bioos workflow submit` already supported preprocessing local file paths from `input.json`, but the old implementation was fragile.

Previous behavior:
- serialized the whole JSON into a string
- used regex to guess path-like substrings
- replaced paths with string-level substitution

Problems in the previous implementation:
- Chinese paths could not be detected reliably
- paths with spaces or more complex characters were fragile
- batch/nested JSON structures were harder to handle safely
- replacement logic was string-based and less precise

New behavior:
- recursively traverse the real JSON structure
- detect local files by checking actual filesystem existence with `os.path.isfile(...)`
- upload detected local files through the shared resilient upload helper
- replace only exact matched local-path values with uploaded `s3://...` locations

This makes preprocessing more robust for:
- singleton `{...}` inputs
- batch `[{...}, {...}]` inputs
- Chinese local paths
- paths containing spaces
- nested `dict` / `list` structures

### 3. Workspace member management

Added new workspace member commands:

- `bioos workspace member list`
- `bioos workspace member add`
- `bioos workspace member update`
- `bioos workspace member delete`

This required:
- new BioOS service bindings
- new workspace resource methods
- new CLI handlers and routing

Also added support for member listing pagination:
- `--page-number`
- `--page-size`

### 4. Account-level usage queries

Added a new top-level `bioos usage` command group for account-level asset and resource queries.

New commands:
- `bioos usage asset-data`
- `bioos usage asset-list`
- `bioos usage asset-total`
- `bioos usage resource-data`
- `bioos usage resource-workspace-list`
- `bioos usage resource-user-list`
- `bioos usage resource-total`

Also added `bioos.usage()` as the SDK entrypoint for this resource family.

### 5. Fix usage permission error handling

Observed issue:
- owner-only usage APIs returned raw backend permission errors when called with a sub-account AK/SK

Fix:
- translate the raw forbidden backend payload into a clearer user-facing error
- explicitly indicate that these APIs require the main account / account owner credentials

### 6. File download improvement for `s3://...`

Observed issue:
- `bioos file download` previously treated `s3://bucket/key` as a literal object key, which caused failures

Fix:
- normalize current-workspace `s3://...` paths back to internal object keys before download
- raise a clear error when the bucket does not match the current workspace bucket

## Compatibility Notes

This PR keeps current compatibility behavior intact:

- `tos` remains pinned to `2.5.6`
- `pandas>=1.3.0` remains supported

A temporary compatibility shim is still used for DataFrame element-wise string conversion during workflow batch preprocessing:
- use `DataFrame.map(...)` when available
- fall back to `DataFrame.applymap(...)` on older pandas versions

This shim is transitional and is expected to be removed in a future release after the minimum pandas version is raised to `2.1+`.

## Testing

### Unit tests

Added and updated unit tests for:
- file upload CLI and upload parameter pass-through
- workflow local-file preprocessing
- Chinese path detection
- batch input handling
- `drs://...` pass-through behavior
- download normalization for `s3://...`
- workspace member commands
- member list pagination and filtering behavior
- usage command handlers and resource validation
- clearer owner-only permission error translation



