### PR TITLE
feat: add unified AAI, repository, datasite and DRS download CLI work…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,532 @@ bioos config path
 bioos config example
 ```
 
+## AAI, Repository, and Data Site
+
+`pybioos` now supports the repository and data site APIs that are authenticated through the BioOS main web session and repository passport flow.
+
+Service endpoints used in the current integration:
+
+- BioOS main site: `https://cloud.miracle.ac.cn`
+- Repository site: `https://network.miracle.ac.cn`
+- Data site: `https://mclibrary.miracle.ac.cn`
+
+There are two related authentication layers:
+
+1. BioOS SDK authentication, used by workspace and workflow APIs
+2. BioOS main-web session -> AAI passport exchange, used by repository and data-site APIs
+
+In practice:
+
+- `bioos auth ...` is for SDK-style AK/SK authentication
+- `bioos aai ...` is for main-web login, AAI linkage check, passport exchange, and passport refresh
+- `bioos repo ...` and `bioos datasite ...` use the saved AAI passport by default
+
+Recommended workflow:
+
+1. Log in to the BioOS main site in your browser.
+2. Open browser developer tools and copy any main-site GraphQL request as cURL.
+3. Run one command to extract the main-site auth materials, get a repository passport, and save it into local config:
+
+```bash
+bioos aai sync-from-curl --curl '...copied main-site cURL...' --pretty
+```
+
+If you also want to save the BioOS SDK credentials and then complete the AAI sync in one step, use:
+
+```bash
+bioos auth connect-aai \
+  --ak 'your-access-key' \
+  --sk 'your-secret-key' \
+  --curl '...copied main-site cURL...' \
+  --pretty
+```
+
+This command saves the `client` section, verifies BioOS SDK authentication, saves the resolved `main_web` materials, and then syncs the repository passport into both `repo` and `datasite`.
+
+If you want the CLI to log in to the BioOS main site directly with account/password first, you can now use:
+
+```bash
+bioos aai login \
+  --account-name 'your-account-name' \
+  --password 'your-password' \
+  --pretty
+```
+
+If the BioOS web account is not linked to an AAI repository account yet, the CLI now stops before the passport request and returns a clear linkage hint instead of failing later.
+
+The saved `repo` and `datasite` sections now include `passport_issued_at` and `passport_expires_at`. You can refresh them with:
+
+```bash
+bioos aai refresh --pretty
+```
+
+Or refresh and re-login in one shot:
+
+```bash
+bioos aai refresh \
+  --account-name 'your-account-name' \
+  --password 'your-password' \
+  --pretty
+```
+
+When a saved passport is expired, `bioos repo ...` and `bioos datasite ...` commands now fail fast with a message telling you to run `bioos aai refresh` or `bioos aai login`.
+
+Or combine that with BioOS SDK credential persistence in one step:
+
+```bash
+bioos auth connect-aai \
+  --ak 'your-access-key' \
+  --sk 'your-secret-key' \
+  --account-name 'your-account-name' \
+  --password 'your-password' \
+  --pretty
+```
+
+You can inspect the current AAI-related state at any time:
+
+```bash
+bioos aai status --pretty
+bioos aai auth --service repo --pretty
+bioos aai auth --service datasite --pretty
+```
+
+Typical local config structure after successful AAI login:
+
+```yaml
+main_web:
+  url: "https://cloud.miracle.ac.cn"
+  login_token: "main site X-LoginToken"
+  csrf_token: "main site csrfToken"
+  cookie: "tenant=...; csrfToken=...; ..."
+repo:
+  url: "https://network.miracle.ac.cn"
+  token: "repository passport token"
+  passport_issued_at: "2026-05-07T10:00:00+00:00"
+  passport_expires_at: "2026-06-06T10:00:00+00:00"
+datasite:
+  url: "https://mclibrary.miracle.ac.cn"
+  token: "repository passport token"
+  passport_issued_at: "2026-05-07T10:00:00+00:00"
+  passport_expires_at: "2026-06-06T10:00:00+00:00"
+```
+
+After that, repository and data site commands can use the saved token directly:
+
+```bash
+bioos repo dataset list --page 1 --size 15 --pretty
+bioos datasite dataset list --page 1 --size 15 --pretty
+```
+
+For the data site dataset publishing workflow, the CLI now ships with ready-to-edit JSON examples under [examples/datasite](./examples/datasite) and can also print inline templates:
+
+```bash
+bioos datasite dataset template --kind create --pretty
+bioos datasite dataset template --kind apply --pretty
+bioos datasite dataset template --kind upsert-files --pretty
+bioos datasite dataset template --kind release --pretty
+bioos datasite dataset template --kind update-config --pretty
+```
+
+For data file registration, two template forms are now bundled:
+
+- JSON request body for `bioos datasite dataset upsert-files`: [upsert-files.json](./examples/datasite/upsert-files.json)
+- CSV description template used by the data site front-end import flow: [data-files-template.csv](./examples/datasite/data-files-template.csv)
+
+### Data Site Data Set End-to-End Workflow
+
+1. Check whether the target dataset name is already taken:
+
+```bash
+bioos datasite dataset check-create \
+  --name "mc-dataset-demo" \
+  --pretty
+```
+
+2. Create the dataset from the bundled example payload:
+
+```bash
+bioos datasite dataset create \
+  --json-file ./examples/datasite/create-dataset.json \
+  --pretty
+```
+
+Expected response shape:
+
+```json
+{
+  "id": "replace-with-created-data-set-id"
+}
+```
+
+3. Upload or register files under the new dataset:
+
+```bash
+bioos datasite dataset upsert-files \
+  --data-set-id replace-with-created-data-set-id \
+  --json-file ./examples/datasite/upsert-files.json \
+  --pretty
+```
+
+The `upsert-files` JSON payload uses the real backend field names:
+
+- `dataFiles`: file item list
+- `duplicatedReplace`: whether to replace duplicate files
+- each file item may include `name`, `description`, `createTime`, `updateTime`, `fileType`, `fileSize`, `accessURL`, `source`, and optional `checksums`
+- in the current recommended workflow, users submit the original `s3://...` object location and the service later exposes the generated `drs://...` value in dataset/file query results
+
+If you are preparing file metadata through the same spreadsheet-style process used by the web UI, start from [data-files-template.csv](./examples/datasite/data-files-template.csv). The current front-end validation expects exactly these columns:
+
+```text
+File name,File description,Date created,Last updated,File type,File size,Data source,Data path
+```
+
+CSV validation notes from the current front-end behavior:
+
+- `Date created` and `Last updated` use `YY-MM-DD`
+- `Data path` must start with `s3://` or `drs://`
+- when `Data path` is `drs://...`, `File size` is required
+- file names and data paths must be unique within the imported CSV
+
+Operational recommendation:
+
+- for normal submission into the data site, prefer placing the underlying object location in `accessURL` / `Data path` as `s3://...`
+- treat `drsURL` as a server-generated access identifier returned by follow-up `dataset files`, `file list-drs`, or DRS object queries
+
+4. Optionally update file-table column ordering for the front-end:
+
+```bash
+bioos datasite dataset update-config \
+  --id replace-with-created-data-set-id \
+  --json-file ./examples/datasite/update-config.json \
+  --pretty
+```
+
+5. Inspect the dataset and file list:
+
+```bash
+bioos datasite dataset get \
+  --id replace-with-created-data-set-id \
+  --pretty
+
+bioos datasite dataset files \
+  --data-set-id replace-with-created-data-set-id \
+  --page 1 \
+  --size 20 \
+  --pretty
+```
+
+6. Submit the publish/application step:
+
+Before calling `apply`, update `dataSetID` inside [apply-dataset.json](./examples/datasite/apply-dataset.json) to the real dataset ID returned by `create`.
+
+```bash
+bioos datasite dataset apply \
+  --json-file ./examples/datasite/apply-dataset.json \
+  --pretty
+```
+
+7. Release the dataset when it is ready to be published:
+
+```bash
+bioos datasite dataset release \
+  --id replace-with-created-data-set-id \
+  --json-file ./examples/datasite/release-dataset.json \
+  --pretty
+```
+
+8. If needed, revoke the published state later:
+
+```bash
+bioos datasite dataset revoke \
+  --id replace-with-created-data-set-id \
+  --json '{}'
+```
+
+9. If you need to remove registered files:
+
+```bash
+bioos datasite dataset delete-files \
+  --data-set-id replace-with-created-data-set-id \
+  --json-file ./examples/datasite/delete-files.json \
+  --pretty
+```
+
+Notes for the workflow above:
+
+- `create`, `apply`, `update`, `update-config`, `delete`, `release`, `revoke`, `upsert-files`, and `delete-files` all support both saved AAI auth and explicit `--token` / `--cookie` overrides
+- the bundled example payloads are intentionally conservative and should be edited to match the real category, catalogue, links, contacts, and file metadata for your dataset
+- the backend field names follow the real browser/API behavior, so keeping payload keys exactly as shown is recommended
+- if your current runtime depends on cookie-auth in addition to the saved passport token, you can append `--cookie 'ory_kratos_session=...'` to the same commands
+
+Useful inspection commands:
+
+```bash
+bioos aai status
+bioos aai account status \
+  --web-url https://cloud.miracle.ac.cn \
+  --login-token '...' \
+  --csrf-token '...' \
+  --cookie '...' \
+  --pretty
+```
+
+If you want to separate extraction and sync:
+
+```bash
+bioos aai import-main-web-curl --curl '...copied main-site cURL...' --pretty
+
+bioos aai sync-from-bioos \
+  --web-url https://cloud.miracle.ac.cn \
+  --login-token '...' \
+  --csrf-token '...' \
+  --cookie '...' \
+  --expires-in 2592000 \
+  --pretty
+```
+
+## Data Access Workflow
+
+The most common read-only data access path is:
+
+1. log in through `bioos aai login`
+2. list datasets from `datasite` or `repo`
+3. inspect one dataset
+4. list dataset files
+5. extract `drs://...` values
+6. resolve DRS into downloadable HTTPS access
+7. download one file or batch-download a filtered subset
+
+The CLI now supports this end to end.
+
+### Data Access Commands
+
+List data-site datasets:
+
+```bash
+bioos datasite dataset list --page 1 --size 15 --pretty
+```
+
+Get one dataset:
+
+```bash
+bioos datasite dataset get \
+  --id <DATA_SET_ID> \
+  --pretty
+```
+
+List files under one dataset:
+
+```bash
+bioos datasite dataset files \
+  --data-set-id <DATA_SET_ID> \
+  --page 1 \
+  --size 100 \
+  --pretty
+```
+
+List only DRS links from a dataset:
+
+```bash
+bioos datasite file list-drs \
+  --data-set-id <DATA_SET_ID> \
+  --page 1 \
+  --size 100 \
+  --pretty
+```
+
+Resolve a single DRS URL:
+
+```bash
+bioos datasite drs resolve \
+  --drs-url 'drs://imc-drs.miracle.ac.cn/<OBJECT_ID>' \
+  --pretty
+```
+
+Download a single DRS object:
+
+```bash
+bioos datasite drs download \
+  --drs-url 'drs://imc-drs.miracle.ac.cn/<OBJECT_ID>' \
+  --target ./downloads \
+  --pretty
+```
+
+Batch-download filtered files from a dataset:
+
+```bash
+bioos datasite dataset download-files \
+  --data-set-id <DATA_SET_ID> \
+  --target ./downloads \
+  --name-contains 'tumor' \
+  --pretty
+```
+
+Useful filtering options for `bioos datasite dataset download-files`:
+
+- `--name-contains`: case-insensitive substring filter on file name
+- `--regex`: regular expression on file name
+- `--drs-url`: exact-match one DRS URL
+- `--limit`: cap the number of matched files
+- `--dry-run`: preview matches without downloading
+
+Examples:
+
+```bash
+bioos datasite dataset download-files \
+  --data-set-id <DATA_SET_ID> \
+  --target ./downloads \
+  --regex '.*\\.(fastq|fastq\\.gz|bam)$' \
+  --limit 10 \
+  --pretty
+
+bioos datasite dataset download-files \
+  --data-set-id <DATA_SET_ID> \
+  --target ./downloads \
+  --name-contains 'tumor' \
+  --dry-run \
+  --pretty
+```
+
+## Complete Example: Login to Batch Download
+
+This example shows a complete data-access chain from BioOS main-site login to dataset file download.
+
+### Step 1: Log in through BioOS main-web and sync AAI passport
+
+```bash
+bioos aai login \
+  --account-name 'your-account-name' \
+  --password 'your-password' \
+  --pretty
+```
+
+Expected outcome:
+
+- main-web session materials are saved into `main_web`
+- AAI linkage is checked before passport exchange
+- if linked, repository passport is saved into both `repo` and `datasite`
+
+### Step 2: Verify passport status
+
+```bash
+bioos aai status --pretty
+```
+
+Look for:
+
+- `repo.token_configured: true`
+- `datasite.token_configured: true`
+- `repo.passport_status: valid`
+- `datasite.passport_status: valid`
+
+If the passport is expired:
+
+```bash
+bioos aai refresh --pretty
+```
+
+### Step 3: Find a dataset
+
+```bash
+bioos datasite dataset list \
+  --page 1 \
+  --size 15 \
+  --pretty
+```
+
+Pick one `id` from the output. In the examples below, suppose the dataset ID is:
+
+```text
+td45e334illb3o00f6o9g
+```
+
+### Step 4: Inspect the dataset and its files
+
+```bash
+bioos datasite dataset get \
+  --id td45e334illb3o00f6o9g \
+  --pretty
+
+bioos datasite dataset files \
+  --data-set-id td45e334illb3o00f6o9g \
+  --page 1 \
+  --size 100 \
+  --pretty
+```
+
+### Step 5: Extract DRS URLs
+
+```bash
+bioos datasite file list-drs \
+  --data-set-id td45e334illb3o00f6o9g \
+  --page 1 \
+  --size 100 \
+  --pretty
+```
+
+Suppose one returned item contains:
+
+```text
+drs://imc-drs.miracle.ac.cn/ect4n4cphqtu9gcn9t05g
+```
+
+### Step 6: Resolve and download one file
+
+```bash
+bioos datasite drs resolve \
+  --drs-url 'drs://imc-drs.miracle.ac.cn/ect4n4cphqtu9gcn9t05g' \
+  --pretty
+
+bioos datasite drs download \
+  --drs-url 'drs://imc-drs.miracle.ac.cn/ect4n4cphqtu9gcn9t05g' \
+  --target ./downloads \
+  --pretty
+```
+
+### Step 7: Batch-download matching files from the same dataset
+
+Preview matches first:
+
+```bash
+bioos datasite dataset download-files \
+  --data-set-id td45e334illb3o00f6o9g \
+  --target ./downloads \
+  --name-contains 'fastq' \
+  --dry-run \
+  --pretty
+```
+
+Then perform the real download:
+
+```bash
+bioos datasite dataset download-files \
+  --data-set-id td45e334illb3o00f6o9g \
+  --target ./downloads \
+  --name-contains 'fastq' \
+  --pretty
+```
+
+Or use a stricter regex:
+
+```bash
+bioos datasite dataset download-files \
+  --data-set-id td45e334illb3o00f6o9g \
+  --target ./downloads \
+  --regex '.*\\.(fastq|fastq\\.gz)$' \
+  --limit 20 \
+  --pretty
+```
+
+### Notes for the End-to-End Data Chain
+
+- `dataset files` returns file metadata; `drsURL` is usually the key bridge to actual download
+- `drs resolve` helps when you need to inspect object and access details before downloading
+- `drs download` is best for one known file
+- `dataset download-files` is best for repeated operational use on one dataset
+- if you accidentally paste a malformed DRS URL, such as one with an extra trailing quote, the object lookup will fail with 404
+- if a saved passport expires, `repo` and `datasite` commands now fail with a refresh hint rather than a vague downstream auth error
+
 ## Legacy Compatibility
 
 The following legacy commands are still available for compatibility:

--- a/bioos/cli/common.py
+++ b/bioos/cli/common.py
@@ -3,7 +3,7 @@ import json
 import sys
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 
 def _json_default(value: Any) -> Any:
@@ -68,6 +68,21 @@ def add_output_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_json_input_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--json",
+        dest="json_input",
+        default=None,
+        help="Inline JSON request body.",
+    )
+    parser.add_argument(
+        "--json-file",
+        dest="json_file",
+        default=None,
+        help="Path to a JSON request body file, or - to read from stdin.",
+    )
+
+
 def add_argument(parser: argparse.ArgumentParser, name: str, *args: Any, **kwargs: Any) -> None:
     cli_name = f"--{name.replace('_', '-')}"
     legacy_name = f"--{name}"
@@ -107,6 +122,23 @@ def add_bool_argument(
             action="store_false",
             help=f"Disable: {help_text}",
         )
+
+
+def load_json_input(args: argparse.Namespace) -> Dict[str, Any]:
+    json_input = getattr(args, "json_input", None)
+    json_file = getattr(args, "json_file", None)
+    if json_input and json_file:
+        raise ValueError("Use only one of --json or --json-file.")
+    if json_input:
+        payload = json.loads(json_input)
+    elif json_file:
+        content = sys.stdin.read() if json_file == "-" else Path(json_file).read_text(encoding="utf-8")
+        payload = json.loads(content)
+    else:
+        payload = {}
+    if not isinstance(payload, dict):
+        raise ValueError("JSON input must decode to an object.")
+    return payload
 
 
 def emit_output(data: Any, output: str = "json", pretty: bool = False) -> None:

--- a/bioos/cli/config_store.py
+++ b/bioos/cli/config_store.py
@@ -10,6 +10,21 @@ EXAMPLE_CONFIG = """client:
   MIRACLE_SECRET_KEY: "SKxxxx"
   serveraddr: "https://bio-top.miracle.ac.cn"
   region: "cn-north-1"
+main_web:
+  url: "https://cloud.miracle.ac.cn"
+  login_token: "main site X-LoginToken"
+  csrf_token: "main site csrfToken cookie value"
+  cookie: "csrfToken=...; tenant=...; other web cookies"
+repo:
+  url: "https://network.miracle.ac.cn"
+  token: "AAI token or session token"
+  cookie: "ory_kratos_session=..."
+datasite:
+  url: "https://mclibrary.miracle.ac.cn"
+  token: "AAI token or session token"
+  cookie: "ory_kratos_session=..."
+account:
+  link_mode: "aai"
 """
 
 
@@ -29,11 +44,60 @@ def load_config(path: Optional[str] = None) -> Dict[str, Any]:
     return _load_yaml_like(config_path.read_text(encoding="utf-8"))
 
 
+def save_config(config: Dict[str, Any], path: Optional[str] = None) -> Path:
+    config_path = get_config_path(path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(_dump_yaml_like(config), encoding="utf-8")
+    return config_path
+
+
+def update_section_values(section: str, values: Dict[str, Any], path: Optional[str] = None) -> Path:
+    config = load_config(path)
+    existing = config.get(section)
+    if not isinstance(existing, dict):
+        existing = {}
+    existing.update(values)
+    config[section] = existing
+    return save_config(config, path=path)
+
+
 def load_client_config(path: Optional[str] = None) -> Dict[str, Any]:
     config = load_config(path)
     client = config.get("client")
     if isinstance(client, dict):
         return client
+    return {}
+
+
+def load_main_web_config(path: Optional[str] = None) -> Dict[str, Any]:
+    config = load_config(path)
+    main_web = config.get("main_web")
+    if isinstance(main_web, dict):
+        return main_web
+    return {}
+
+
+def load_repo_config(path: Optional[str] = None) -> Dict[str, Any]:
+    config = load_config(path)
+    repo = config.get("repo")
+    if isinstance(repo, dict):
+        return repo
+    return {}
+
+
+def load_datasite_config(path: Optional[str] = None) -> Dict[str, Any]:
+    config = load_config(path)
+    datasite = config.get("datasite")
+    if isinstance(datasite, dict):
+        return datasite
+    return {}
+
+
+def load_account_config(path: Optional[str] = None) -> Dict[str, Any]:
+    config = load_config(path)
+    account = config.get("account")
+    if isinstance(account, dict):
+        return account
     return {}
 
 
@@ -85,3 +149,25 @@ def _parse_scalar(value: str) -> Any:
     if lowered == "false":
         return False
     return value
+
+
+def _dump_yaml_like(data: Dict[str, Any]) -> str:
+    lines = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            lines.append(f"{key}:")
+            for sub_key, sub_value in value.items():
+                lines.append(f"  {sub_key}: {_format_scalar(sub_value)}")
+        else:
+            lines.append(f"{key}: {_format_scalar(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def _format_scalar(value: Any) -> str:
+    if value is None:
+        return '""'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    text = str(value)
+    escaped = text.replace('"', '\\"')
+    return f'"{escaped}"'

--- a/bioos/cli/main.py
+++ b/bioos/cli/main.py
@@ -1,6 +1,11 @@
 import argparse
+import re
 import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Iterable, Optional
+from urllib.parse import urlparse
 
 from bioos import bioos_workflow, bw_import, bw_import_status_check, bw_status_check, get_submission_logs
 from bioos.cli import (
@@ -31,7 +36,15 @@ from bioos.cli import (
     update_workspace_members,
     validate_wdl,
 )
-from bioos.cli.common import add_argument, add_auth_arguments, add_bool_argument, add_output_arguments, run_cli
+from bioos.cli.common import (
+    add_argument,
+    add_auth_arguments,
+    add_bool_argument,
+    add_json_input_arguments,
+    add_output_arguments,
+    load_json_input,
+    run_cli,
+)
 from bioos.cli.config_store import EXAMPLE_CONFIG, get_config_path
 from bioos.ops.auth import login_to_bioos, resolve_auth_settings
 
@@ -44,11 +57,15 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     _add_auth_group(subparsers)
+    _add_aai_group(subparsers)
+    _add_account_group(subparsers)
     _add_config_group(subparsers)
     _add_workspace_group(subparsers)
     _add_workflow_group(subparsers)
     _add_submission_group(subparsers)
     _add_file_group(subparsers)
+    _add_repo_group(subparsers)
+    _add_datasite_group(subparsers)
     _add_usage_group(subparsers)
     _add_ies_group(subparsers)
     _add_dockstore_group(subparsers)
@@ -78,6 +95,203 @@ def _add_auth_group(subparsers: Any) -> None:
     add_output_arguments(status_parser)
     status_parser.set_defaults(_parser=status_parser)
     status_parser.set_defaults(handler=_handle_auth_status)
+
+    connect_aai_parser = auth_subparsers.add_parser(
+        "connect-aai",
+        help="Save BioOS SDK credentials, verify BioOS auth, then save/sync AAI repository passport in one step.",
+    )
+    add_auth_arguments(connect_aai_parser)
+    add_output_arguments(connect_aai_parser)
+    add_argument(connect_aai_parser, "account_name", required=False, default=None, help="BioOS main-site account name for password login.")
+    add_argument(connect_aai_parser, "password", required=False, default=None, help="BioOS main-site password for password login.")
+    add_argument(connect_aai_parser, "user_name", required=False, default=None, help="Optional sub-user name for main-site user login.")
+    add_argument(connect_aai_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(connect_aai_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(connect_aai_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(connect_aai_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    add_argument(connect_aai_parser, "curl", required=False, default=None, help="Inline cURL command copied from the BioOS main web GraphQL request.")
+    add_argument(connect_aai_parser, "curl_file", required=False, default=None, help="Path to a text file containing the copied cURL command.")
+    add_bool_argument(
+        connect_aai_parser,
+        "save_client",
+        default=True,
+        help_text="Save BioOS SDK credentials into config before AAI sync.",
+    )
+    add_bool_argument(
+        connect_aai_parser,
+        "save_main_web",
+        default=True,
+        help_text="Save resolved BioOS main-web auth materials into config before syncing passport.",
+    )
+    add_bool_argument(
+        connect_aai_parser,
+        "sync_passport",
+        default=True,
+        help_text="Get repository passport and save it into repo/datasite config.",
+    )
+    add_argument(connect_aai_parser, "expires_in", required=False, type=int, default=2592000, help="Passport expiration in seconds. Defaults to 30 days.")
+    add_argument(connect_aai_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    connect_aai_parser.set_defaults(_parser=connect_aai_parser)
+    connect_aai_parser.set_defaults(handler=_handle_auth_connect_aai)
+
+
+def _add_aai_group(subparsers: Any) -> None:
+    aai_parser = subparsers.add_parser("aai", help="AAI authentication commands.")
+    aai_subparsers = aai_parser.add_subparsers(dest="aai_command")
+    aai_parser.set_defaults(_parser=aai_parser)
+
+    auth_parser = aai_subparsers.add_parser("auth", help="Show AAI auth settings.")
+    add_output_arguments(auth_parser)
+    add_argument(auth_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(
+        auth_parser,
+        "cookie",
+        required=False,
+        default=None,
+        help="AAI session cookie override, e.g. ory_kratos_session=... .",
+    )
+    add_argument(auth_parser, "service", required=False, default="repo", help="Target service: repo or datasite.")
+    auth_parser.set_defaults(_parser=auth_parser)
+    auth_parser.set_defaults(handler=_handle_aai_auth)
+
+    status_parser = aai_subparsers.add_parser("status", help="Show a consolidated view of main-web, repo, and datasite authentication status.")
+    add_output_arguments(status_parser)
+    add_argument(status_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(status_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(status_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(status_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    status_parser.set_defaults(_parser=status_parser)
+    status_parser.set_defaults(handler=_handle_aai_status)
+
+    import_curl_parser = aai_subparsers.add_parser("import-main-web-curl", help="Extract BioOS main web auth materials from a copied cURL command.")
+    add_output_arguments(import_curl_parser)
+    add_argument(import_curl_parser, "curl", required=False, default=None, help="Inline cURL command copied from the BioOS main web GraphQL request.")
+    add_argument(import_curl_parser, "curl_file", required=False, default=None, help="Path to a text file containing the copied cURL command.")
+    import_curl_parser.set_defaults(_parser=import_curl_parser)
+    import_curl_parser.set_defaults(handler=_handle_aai_import_main_web_curl)
+
+    login_parser = aai_subparsers.add_parser(
+        "login",
+        help="Unified AAI login entry: import BioOS main web auth materials, optionally save them, then sync repository passport.",
+    )
+    add_output_arguments(login_parser)
+    add_argument(login_parser, "account_name", required=False, default=None, help="BioOS main-site account name for password login.")
+    add_argument(login_parser, "password", required=False, default=None, help="BioOS main-site password for password login.")
+    add_argument(login_parser, "user_name", required=False, default=None, help="Optional sub-user name for main-site user login.")
+    add_argument(login_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(login_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(login_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(login_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    add_argument(login_parser, "curl", required=False, default=None, help="Inline cURL command copied from the BioOS main web GraphQL request.")
+    add_argument(login_parser, "curl_file", required=False, default=None, help="Path to a text file containing the copied cURL command.")
+    add_bool_argument(
+        login_parser,
+        "save_main_web",
+        default=True,
+        help_text="Save resolved BioOS main-web auth materials into config before syncing passport.",
+    )
+    add_bool_argument(
+        login_parser,
+        "sync_passport",
+        default=True,
+        help_text="Get repository passport and save it into repo/datasite config.",
+    )
+    add_argument(login_parser, "expires_in", required=False, type=int, default=2592000, help="Passport expiration in seconds. Defaults to 30 days.")
+    add_argument(login_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    login_parser.set_defaults(_parser=login_parser)
+    login_parser.set_defaults(handler=_handle_aai_login)
+
+    refresh_parser = aai_subparsers.add_parser(
+        "refresh",
+        help="Refresh repository passport using saved or provided BioOS main-web auth materials.",
+    )
+    add_output_arguments(refresh_parser)
+    add_argument(refresh_parser, "account_name", required=False, default=None, help="BioOS main-site account name for password login.")
+    add_argument(refresh_parser, "password", required=False, default=None, help="BioOS main-site password for password login.")
+    add_argument(refresh_parser, "user_name", required=False, default=None, help="Optional sub-user name for main-site user login.")
+    add_argument(refresh_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(refresh_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(refresh_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(refresh_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    add_argument(refresh_parser, "curl", required=False, default=None, help="Inline cURL command copied from the BioOS main web GraphQL request.")
+    add_argument(refresh_parser, "curl_file", required=False, default=None, help="Path to a text file containing the copied cURL command.")
+    add_bool_argument(
+        refresh_parser,
+        "save_main_web",
+        default=True,
+        help_text="Save resolved BioOS main-web auth materials into config before refreshing passport.",
+    )
+    add_argument(refresh_parser, "expires_in", required=False, type=int, default=2592000, help="Passport expiration in seconds. Defaults to 30 days.")
+    add_argument(refresh_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    refresh_parser.set_defaults(_parser=refresh_parser)
+    refresh_parser.set_defaults(handler=_handle_aai_refresh)
+
+    sync_curl_parser = aai_subparsers.add_parser("sync-from-curl", help="Extract BioOS main web auth materials from a copied cURL command, then get and save repository passport.")
+    add_output_arguments(sync_curl_parser)
+    add_argument(sync_curl_parser, "curl", required=False, default=None, help="Inline cURL command copied from the BioOS main web GraphQL request.")
+    add_argument(sync_curl_parser, "curl_file", required=False, default=None, help="Path to a text file containing the copied cURL command.")
+    add_argument(sync_curl_parser, "expires_in", required=False, type=int, default=2592000, help="Passport expiration in seconds. Defaults to 30 days.")
+    add_argument(sync_curl_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    sync_curl_parser.set_defaults(_parser=sync_curl_parser)
+    sync_curl_parser.set_defaults(handler=_handle_aai_sync_from_curl)
+
+    account_parser = aai_subparsers.add_parser("account", help="AAI repository account linkage via BioOS main site.")
+    account_subparsers = account_parser.add_subparsers(dest="aai_account_command")
+    account_parser.set_defaults(_parser=account_parser)
+
+    account_status_parser = account_subparsers.add_parser("status", help="Check whether the current BioOS web account is linked to repository AAI.")
+    add_output_arguments(account_status_parser)
+    add_argument(account_status_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(account_status_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(account_status_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(account_status_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    account_status_parser.set_defaults(_parser=account_status_parser)
+    account_status_parser.set_defaults(handler=_handle_aai_account_status)
+
+    passport_parser = aai_subparsers.add_parser("passport", help="Repository passport retrieval via BioOS main site.")
+    passport_subparsers = passport_parser.add_subparsers(dest="aai_passport_command")
+    passport_parser.set_defaults(_parser=passport_parser)
+
+    passport_get_parser = passport_subparsers.add_parser("get", help="Get repository passport from current BioOS web account.")
+    add_output_arguments(passport_get_parser)
+    add_argument(passport_get_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(passport_get_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(passport_get_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(passport_get_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    add_argument(passport_get_parser, "expires_in", required=False, type=int, default=None, help="Optional passport expiration in seconds.")
+    add_argument(
+        passport_get_parser,
+        "save_to",
+        required=False,
+        action="append",
+        help="Save passport token into config section(s): repo, datasite. Can be repeated.",
+    )
+    add_argument(passport_get_parser, "config_path", required=False, default=None, help="Optional config path override when saving.")
+    passport_get_parser.set_defaults(_parser=passport_get_parser)
+    passport_get_parser.set_defaults(handler=_handle_aai_passport_get)
+
+    sync_parser = aai_subparsers.add_parser("sync-from-bioos", help="Get repository passport from current BioOS web account and save it into repo/datasite config.")
+    add_output_arguments(sync_parser)
+    add_argument(sync_parser, "web_url", required=False, default=None, help="BioOS main site web URL override.")
+    add_argument(sync_parser, "login_token", required=False, default=None, help="BioOS main site X-LoginToken override.")
+    add_argument(sync_parser, "csrf_token", required=False, default=None, help="BioOS main site csrfToken override.")
+    add_argument(sync_parser, "cookie", required=False, default=None, help="BioOS main site web cookie override.")
+    add_argument(sync_parser, "expires_in", required=False, type=int, default=2592000, help="Passport expiration in seconds. Defaults to 30 days.")
+    add_argument(sync_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    sync_parser.set_defaults(_parser=sync_parser)
+    sync_parser.set_defaults(handler=_handle_aai_sync_from_bioos)
+
+
+def _add_account_group(subparsers: Any) -> None:
+    account_parser = subparsers.add_parser("account", help="BioOS and AAI account linking commands.")
+    account_subparsers = account_parser.add_subparsers(dest="account_command")
+    account_parser.set_defaults(_parser=account_parser)
+
+    link_parser = account_subparsers.add_parser("link", help="Show account link settings.")
+    add_output_arguments(link_parser)
+    add_argument(link_parser, "config_path", required=False, default=None, help="Optional config path override.")
+    link_parser.set_defaults(_parser=link_parser)
+    link_parser.set_defaults(handler=_handle_account_link)
 
 
 def _add_config_group(subparsers: Any) -> None:
@@ -489,6 +703,659 @@ def _add_file_group(subparsers: Any) -> None:
     download_parser.set_defaults(handler=download_files_from_workspace.handle)
 
 
+def _add_repo_group(subparsers: Any) -> None:
+    repo_parser = subparsers.add_parser("repo", help="Repository commands.")
+    repo_subparsers = repo_parser.add_subparsers(dest="repo_command")
+    repo_parser.set_defaults(_parser=repo_parser)
+
+    dataset_parser = repo_subparsers.add_parser("dataset", help="Repository data set commands.")
+    dataset_subparsers = dataset_parser.add_subparsers(dest="dataset_command")
+    dataset_parser.set_defaults(_parser=dataset_parser)
+
+    dataset_list_parser = dataset_subparsers.add_parser("list", help="List repository data sets.")
+    add_output_arguments(dataset_list_parser)
+    add_argument(dataset_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(dataset_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(dataset_list_parser, "display_level", required=False, default="Minimal", help="Display level, e.g. Minimal.")
+    add_argument(dataset_list_parser, "order_by", required=False, default="createTime:desc,id:desc", help="Sort order.")
+    dataset_list_parser.set_defaults(_parser=dataset_list_parser)
+    dataset_list_parser.set_defaults(handler=_handle_repo_dataset_list)
+
+    dataset_get_parser = dataset_subparsers.add_parser("get", help="Get a repository data set.")
+    add_output_arguments(dataset_get_parser)
+    add_argument(dataset_get_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_get_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_get_parser, "id", required=True, help="Repository data set ID.")
+    dataset_get_parser.set_defaults(_parser=dataset_get_parser)
+    dataset_get_parser.set_defaults(handler=_handle_repo_dataset_get)
+
+    dataset_export_parser = dataset_subparsers.add_parser("export", help="Start or request a repository data set export.")
+    add_output_arguments(dataset_export_parser)
+    add_json_input_arguments(dataset_export_parser)
+    add_argument(dataset_export_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_export_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_export_parser, "data_set_id", required=True, help="Repository data set ID.")
+    dataset_export_parser.set_defaults(_parser=dataset_export_parser)
+    dataset_export_parser.set_defaults(handler=_handle_repo_dataset_export)
+
+    dataset_import_parser = dataset_subparsers.add_parser("import", help="Import a repository data set from JSON payload.")
+    add_output_arguments(dataset_import_parser)
+    add_json_input_arguments(dataset_import_parser)
+    add_argument(dataset_import_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_import_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    dataset_import_parser.set_defaults(_parser=dataset_import_parser)
+    dataset_import_parser.set_defaults(handler=_handle_repo_dataset_import)
+
+    dataset_archive_parser = dataset_subparsers.add_parser("archive-access", help="Get repository archive TOS access info.")
+    add_output_arguments(dataset_archive_parser)
+    add_argument(dataset_archive_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_archive_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_archive_parser, "path", required=False, default=None, help="Optional archive path.")
+    dataset_archive_parser.set_defaults(_parser=dataset_archive_parser)
+    dataset_archive_parser.set_defaults(handler=_handle_repo_dataset_archive_access)
+
+    dataset_files_parser = dataset_subparsers.add_parser("files", help="List files under a repository data set.")
+    add_output_arguments(dataset_files_parser)
+    add_argument(dataset_files_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_files_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_files_parser, "data_set_id", required=True, help="Repository data set ID.")
+    add_argument(dataset_files_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(dataset_files_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(dataset_files_parser, "order_by", required=False, default=None, help="Sort order, e.g. id:asc.")
+    dataset_files_parser.set_defaults(_parser=dataset_files_parser)
+    dataset_files_parser.set_defaults(handler=_handle_repo_dataset_files)
+
+    dataset_file_ids_parser = dataset_subparsers.add_parser("file-ids", help="List file IDs under a repository data set.")
+    add_output_arguments(dataset_file_ids_parser)
+    add_argument(dataset_file_ids_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_file_ids_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_file_ids_parser, "data_set_id", required=True, help="Repository data set ID.")
+    dataset_file_ids_parser.set_defaults(_parser=dataset_file_ids_parser)
+    dataset_file_ids_parser.set_defaults(handler=_handle_repo_dataset_file_ids)
+
+    dac_parser = repo_subparsers.add_parser("dac", help="Repository DAC commands.")
+    dac_subparsers = dac_parser.add_subparsers(dest="dac_command")
+    dac_parser.set_defaults(_parser=dac_parser)
+
+    dac_list_parser = dac_subparsers.add_parser("list", help="List DACs.")
+    add_output_arguments(dac_list_parser)
+    add_argument(dac_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dac_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dac_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(dac_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(dac_list_parser, "limit", required=False, type=int, default=None, help="Optional limit.")
+    add_argument(dac_list_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    dac_list_parser.set_defaults(_parser=dac_list_parser)
+    dac_list_parser.set_defaults(handler=_handle_repo_dac_list)
+
+    dac_create_parser = dac_subparsers.add_parser("create", help="Create a DAC from JSON payload.")
+    add_output_arguments(dac_create_parser)
+    add_json_input_arguments(dac_create_parser)
+    add_argument(dac_create_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dac_create_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    dac_create_parser.set_defaults(_parser=dac_create_parser)
+    dac_create_parser.set_defaults(handler=_handle_repo_dac_create)
+
+    dac_update_parser = dac_subparsers.add_parser("update", help="Update a DAC from JSON payload.")
+    add_output_arguments(dac_update_parser)
+    add_json_input_arguments(dac_update_parser)
+    add_argument(dac_update_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dac_update_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dac_update_parser, "id", required=True, help="DAC ID.")
+    dac_update_parser.set_defaults(_parser=dac_update_parser)
+    dac_update_parser.set_defaults(handler=_handle_repo_dac_update)
+
+    dac_delete_parser = dac_subparsers.add_parser("delete", help="Delete a DAC.")
+    add_output_arguments(dac_delete_parser)
+    add_argument(dac_delete_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dac_delete_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dac_delete_parser, "id", required=True, help="DAC ID.")
+    dac_delete_parser.set_defaults(_parser=dac_delete_parser)
+    dac_delete_parser.set_defaults(handler=_handle_repo_dac_delete)
+
+    dac_check_parser = dac_subparsers.add_parser("check-create", help="Check whether a DAC can be created.")
+    add_output_arguments(dac_check_parser)
+    add_argument(dac_check_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dac_check_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dac_check_parser, "name", required=False, default=None, help="Optional DAC name to validate.")
+    dac_check_parser.set_defaults(_parser=dac_check_parser)
+    dac_check_parser.set_defaults(handler=_handle_repo_dac_check)
+
+    member_parser = dac_subparsers.add_parser("member", help="Repository DAC member commands.")
+    member_subparsers = member_parser.add_subparsers(dest="member_command")
+    member_parser.set_defaults(_parser=member_parser)
+
+    member_list_parser = member_subparsers.add_parser("list", help="List DAC members.")
+    add_output_arguments(member_list_parser)
+    add_argument(member_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(member_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(member_list_parser, "dac_id", required=True, help="DAC ID.")
+    add_argument(member_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(member_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    member_list_parser.set_defaults(_parser=member_list_parser)
+    member_list_parser.set_defaults(handler=_handle_repo_dac_member_list)
+
+    member_upsert_parser = member_subparsers.add_parser("upsert", help="Create or update DAC members from JSON payload.")
+    add_output_arguments(member_upsert_parser)
+    add_json_input_arguments(member_upsert_parser)
+    add_argument(member_upsert_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(member_upsert_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(member_upsert_parser, "dac_id", required=True, help="DAC ID.")
+    member_upsert_parser.set_defaults(_parser=member_upsert_parser)
+    member_upsert_parser.set_defaults(handler=_handle_repo_dac_member_upsert)
+
+    member_remove_parser = member_subparsers.add_parser("remove", help="Remove DAC members using JSON payload.")
+    add_output_arguments(member_remove_parser)
+    add_json_input_arguments(member_remove_parser)
+    add_argument(member_remove_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(member_remove_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(member_remove_parser, "dac_id", required=True, help="DAC ID.")
+    member_remove_parser.set_defaults(_parser=member_remove_parser)
+    member_remove_parser.set_defaults(handler=_handle_repo_dac_member_remove)
+
+    file_parser = repo_subparsers.add_parser("file", help="Repository file commands.")
+    file_subparsers = file_parser.add_subparsers(dest="file_command")
+    file_parser.set_defaults(_parser=file_parser)
+
+    file_list_parser = file_subparsers.add_parser("list-by-dataset", help="List files under a repository data set.")
+    add_output_arguments(file_list_parser)
+    add_argument(file_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(file_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(file_list_parser, "data_set_id", required=True, help="Repository data set ID.")
+    add_argument(file_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(file_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(file_list_parser, "order_by", required=False, default=None, help="Sort order, e.g. id:asc.")
+    file_list_parser.set_defaults(_parser=file_list_parser)
+    file_list_parser.set_defaults(handler=_handle_repo_dataset_files)
+
+    file_ids_parser = file_subparsers.add_parser("ids", help="List file IDs under a repository data set.")
+    add_output_arguments(file_ids_parser)
+    add_argument(file_ids_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(file_ids_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(file_ids_parser, "data_set_id", required=True, help="Repository data set ID.")
+    file_ids_parser.set_defaults(_parser=file_ids_parser)
+    file_ids_parser.set_defaults(handler=_handle_repo_dataset_file_ids)
+
+    application_parser = repo_subparsers.add_parser("application", help="Repository application commands.")
+    application_subparsers = application_parser.add_subparsers(dest="application_command")
+    application_parser.set_defaults(_parser=application_parser)
+
+    application_list_parser = application_subparsers.add_parser("list", help="List repository applications.")
+    add_output_arguments(application_list_parser)
+    add_argument(application_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(application_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(application_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(application_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(application_list_parser, "app_type", required=False, default=None, help="Application type.")
+    add_argument(application_list_parser, "field", required=False, default=None, help="Field filter.")
+    add_bool_argument(application_list_parser, "show_pending_approval", default=False, help_text="Include pending approvals.")
+    application_list_parser.set_defaults(_parser=application_list_parser)
+    application_list_parser.set_defaults(handler=_handle_repo_application_list)
+
+    library_parser = repo_subparsers.add_parser("library", help="Repository data library commands.")
+    library_subparsers = library_parser.add_subparsers(dest="library_command")
+    library_parser.set_defaults(_parser=library_parser)
+
+    library_list_parser = library_subparsers.add_parser("list", help="List repository data libraries.")
+    add_output_arguments(library_list_parser)
+    add_argument(library_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(library_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    library_list_parser.set_defaults(_parser=library_list_parser)
+    library_list_parser.set_defaults(handler=_handle_repo_library_list)
+
+    schema_job_parser = repo_subparsers.add_parser("schema-job", help="Repository schema job commands.")
+    schema_job_subparsers = schema_job_parser.add_subparsers(dest="schema_job_command")
+    schema_job_parser.set_defaults(_parser=schema_job_parser)
+
+    schema_job_list_parser = schema_job_subparsers.add_parser("list", help="List repository schema jobs.")
+    add_output_arguments(schema_job_list_parser)
+    add_argument(schema_job_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_list_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_list_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    add_argument(schema_job_list_parser, "job_type", required=False, default=None, help="Optional job type filter.")
+    schema_job_list_parser.set_defaults(_parser=schema_job_list_parser)
+    schema_job_list_parser.set_defaults(handler=_handle_repo_schema_job_list)
+
+    schema_job_export_parser = schema_job_subparsers.add_parser("export", help="List repository export schema jobs.")
+    add_output_arguments(schema_job_export_parser)
+    add_argument(schema_job_export_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_export_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_export_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_export_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_export_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_export_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    schema_job_export_parser.set_defaults(_parser=schema_job_export_parser)
+    schema_job_export_parser.set_defaults(handler=_handle_repo_schema_job_export)
+
+    schema_job_import_parser = schema_job_subparsers.add_parser("import", help="List repository import schema jobs.")
+    add_output_arguments(schema_job_import_parser)
+    add_argument(schema_job_import_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_import_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_import_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_import_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_import_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_import_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    schema_job_import_parser.set_defaults(_parser=schema_job_import_parser)
+    schema_job_import_parser.set_defaults(handler=_handle_repo_schema_job_import)
+
+    data_site_parser = repo_subparsers.add_parser("data-site", help="Repository data site helper commands.")
+    data_site_subparsers = data_site_parser.add_subparsers(dest="data_site_command")
+    data_site_parser.set_defaults(_parser=data_site_parser)
+
+    pre_signed_url_parser = data_site_subparsers.add_parser("pre-signed-url", help="Get repository data site pre-signed URL.")
+    add_output_arguments(pre_signed_url_parser)
+    add_argument(pre_signed_url_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(pre_signed_url_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(pre_signed_url_parser, "filename", required=True, help="Repository config filename, e.g. repository-config/footer.json.")
+    pre_signed_url_parser.set_defaults(_parser=pre_signed_url_parser)
+    pre_signed_url_parser.set_defaults(handler=_handle_repo_data_site_pre_signed_url)
+
+    pylons_parser = repo_subparsers.add_parser("pylons", help="Repository pylons helper commands.")
+    pylons_subparsers = pylons_parser.add_subparsers(dest="pylons_command")
+    pylons_parser.set_defaults(_parser=pylons_parser)
+
+    admins_parser = pylons_subparsers.add_parser("admins", help="List pylons admins.")
+    add_output_arguments(admins_parser)
+    add_argument(admins_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(admins_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    admins_parser.set_defaults(_parser=admins_parser)
+    admins_parser.set_defaults(handler=_handle_repo_pylons_admins)
+
+    org_names_parser = pylons_subparsers.add_parser("organization-names", help="Resolve organization names by ID.")
+    add_output_arguments(org_names_parser)
+    add_argument(org_names_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(org_names_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(org_names_parser, "id", required=True, help="Organization ID.")
+    org_names_parser.set_defaults(_parser=org_names_parser)
+    org_names_parser.set_defaults(handler=_handle_repo_pylons_organization_names)
+
+    identity_parser = pylons_subparsers.add_parser("identity", help="Resolve identity by ID.")
+    add_output_arguments(identity_parser)
+    add_argument(identity_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(identity_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(identity_parser, "id", required=True, help="Identity ID.")
+    identity_parser.set_defaults(_parser=identity_parser)
+    identity_parser.set_defaults(handler=_handle_repo_pylons_identity)
+
+
+def _add_datasite_group(subparsers: Any) -> None:
+    datasite_parser = subparsers.add_parser("datasite", help="Data site commands.")
+    datasite_subparsers = datasite_parser.add_subparsers(dest="datasite_command")
+    datasite_parser.set_defaults(_parser=datasite_parser)
+
+    application_parser = datasite_subparsers.add_parser("application", help="Data site application commands.")
+    application_subparsers = application_parser.add_subparsers(dest="application_command")
+    application_parser.set_defaults(_parser=application_parser)
+
+    application_list_parser = application_subparsers.add_parser("list", help="List applications.")
+    add_output_arguments(application_list_parser)
+    add_argument(application_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(application_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(application_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(application_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    application_list_parser.set_defaults(_parser=application_list_parser)
+    application_list_parser.set_defaults(handler=_handle_datasite_application_list)
+
+    application_permit_parser = application_subparsers.add_parser("permit", help="Permit an application task.")
+    add_output_arguments(application_permit_parser)
+    add_argument(application_permit_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(application_permit_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(application_permit_parser, "id", required=True, help="Application ID.")
+    add_argument(application_permit_parser, "task_id", required=True, help="Task ID.")
+    application_permit_parser.set_defaults(_parser=application_permit_parser)
+    application_permit_parser.set_defaults(handler=_handle_datasite_application_permit)
+
+    application_reject_parser = application_subparsers.add_parser("reject", help="Reject an application task.")
+    add_output_arguments(application_reject_parser)
+    add_argument(application_reject_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(application_reject_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(application_reject_parser, "id", required=True, help="Application ID.")
+    add_argument(application_reject_parser, "task_id", required=True, help="Task ID.")
+    application_reject_parser.set_defaults(_parser=application_reject_parser)
+    application_reject_parser.set_defaults(handler=_handle_datasite_application_reject)
+
+    dataset_parser = datasite_subparsers.add_parser("dataset", help="Data site data set commands.")
+    dataset_subparsers = dataset_parser.add_subparsers(dest="dataset_command")
+    dataset_parser.set_defaults(_parser=dataset_parser)
+
+    dataset_list_parser = dataset_subparsers.add_parser("list", help="List data site data sets.")
+    add_output_arguments(dataset_list_parser)
+    add_argument(dataset_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(dataset_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(dataset_list_parser, "tab", required=False, default=None, help="Optional tab filter.")
+    add_argument(dataset_list_parser, "display_level", required=False, default="Minimal", help="Display level, e.g. Minimal.")
+    add_argument(dataset_list_parser, "order_by", required=False, default="createTime:desc,id:desc", help="Sort order.")
+    dataset_list_parser.set_defaults(_parser=dataset_list_parser)
+    dataset_list_parser.set_defaults(handler=_handle_datasite_dataset_list)
+
+    dataset_get_parser = dataset_subparsers.add_parser("get", help="Get a data site data set.")
+    add_output_arguments(dataset_get_parser)
+    add_argument(dataset_get_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_get_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_get_parser, "id", required=True, help="Data set ID.")
+    dataset_get_parser.set_defaults(_parser=dataset_get_parser)
+    dataset_get_parser.set_defaults(handler=_handle_datasite_dataset_get)
+
+    dataset_template_parser = dataset_subparsers.add_parser("template", help="Print JSON templates for the data site data set workflow.")
+    add_output_arguments(dataset_template_parser)
+    add_argument(
+        dataset_template_parser,
+        "kind",
+        required=False,
+        default="create",
+        help="Template kind: create, apply, upsert-files, release, update-config, delete-files.",
+    )
+    dataset_template_parser.set_defaults(_parser=dataset_template_parser)
+    dataset_template_parser.set_defaults(handler=_handle_datasite_dataset_template)
+
+    dataset_create_parser = dataset_subparsers.add_parser("create", help="Create a data site data set from JSON payload.")
+    add_output_arguments(dataset_create_parser)
+    add_json_input_arguments(dataset_create_parser)
+    add_argument(dataset_create_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_create_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    dataset_create_parser.set_defaults(_parser=dataset_create_parser)
+    dataset_create_parser.set_defaults(handler=_handle_datasite_dataset_create)
+
+    dataset_apply_parser = dataset_subparsers.add_parser("apply", help="Submit a data site data set application.")
+    add_output_arguments(dataset_apply_parser)
+    add_json_input_arguments(dataset_apply_parser)
+    add_argument(dataset_apply_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_apply_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    dataset_apply_parser.set_defaults(_parser=dataset_apply_parser)
+    dataset_apply_parser.set_defaults(handler=_handle_datasite_dataset_apply)
+
+    dataset_update_parser = dataset_subparsers.add_parser("update", help="Update a data site data set from JSON payload.")
+    add_output_arguments(dataset_update_parser)
+    add_json_input_arguments(dataset_update_parser)
+    add_argument(dataset_update_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_update_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_update_parser, "id", required=True, help="Data set ID.")
+    dataset_update_parser.set_defaults(_parser=dataset_update_parser)
+    dataset_update_parser.set_defaults(handler=_handle_datasite_dataset_update)
+
+    dataset_config_parser = dataset_subparsers.add_parser("update-config", help="Patch data site data set config from JSON payload.")
+    add_output_arguments(dataset_config_parser)
+    add_json_input_arguments(dataset_config_parser)
+    add_argument(dataset_config_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_config_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_config_parser, "id", required=True, help="Data set ID.")
+    dataset_config_parser.set_defaults(_parser=dataset_config_parser)
+    dataset_config_parser.set_defaults(handler=_handle_datasite_dataset_update_config)
+
+    dataset_delete_parser = dataset_subparsers.add_parser("delete", help="Delete a data site data set.")
+    add_output_arguments(dataset_delete_parser)
+    add_argument(dataset_delete_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_delete_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_delete_parser, "id", required=True, help="Data set ID.")
+    dataset_delete_parser.set_defaults(_parser=dataset_delete_parser)
+    dataset_delete_parser.set_defaults(handler=_handle_datasite_dataset_delete)
+
+    dataset_permission_parser = dataset_subparsers.add_parser("get-permission", help="Get data site data set permission.")
+    add_output_arguments(dataset_permission_parser)
+    add_argument(dataset_permission_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_permission_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_permission_parser, "id", required=True, help="Data set ID.")
+    dataset_permission_parser.set_defaults(_parser=dataset_permission_parser)
+    dataset_permission_parser.set_defaults(handler=_handle_datasite_dataset_permission)
+
+    dataset_release_parser = dataset_subparsers.add_parser("release", help="Release a data site data set.")
+    add_output_arguments(dataset_release_parser)
+    add_json_input_arguments(dataset_release_parser)
+    add_argument(dataset_release_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_release_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_release_parser, "id", required=True, help="Data set ID.")
+    dataset_release_parser.set_defaults(_parser=dataset_release_parser)
+    dataset_release_parser.set_defaults(handler=_handle_datasite_dataset_release)
+
+    dataset_revoke_parser = dataset_subparsers.add_parser("revoke", help="Revoke a data site data set.")
+    add_output_arguments(dataset_revoke_parser)
+    add_json_input_arguments(dataset_revoke_parser)
+    add_argument(dataset_revoke_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_revoke_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_revoke_parser, "id", required=True, help="Data set ID.")
+    dataset_revoke_parser.set_defaults(_parser=dataset_revoke_parser)
+    dataset_revoke_parser.set_defaults(handler=_handle_datasite_dataset_revoke)
+
+    dataset_check_parser = dataset_subparsers.add_parser("check-create", help="Check data site data set creation params.")
+    add_output_arguments(dataset_check_parser)
+    add_argument(dataset_check_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_check_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_check_parser, "name", required=False, default=None, help="Optional data set name.")
+    dataset_check_parser.set_defaults(_parser=dataset_check_parser)
+    dataset_check_parser.set_defaults(handler=_handle_datasite_dataset_check)
+
+    dataset_archive_parser = dataset_subparsers.add_parser("archive-access", help="Get data site archive TOS access info.")
+    add_output_arguments(dataset_archive_parser)
+    add_argument(dataset_archive_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_archive_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_archive_parser, "path", required=False, default=None, help="Optional archive path.")
+    dataset_archive_parser.set_defaults(_parser=dataset_archive_parser)
+    dataset_archive_parser.set_defaults(handler=_handle_datasite_dataset_archive_access)
+
+    dataset_export_parser = dataset_subparsers.add_parser("export", help="Start or request a data site data set export.")
+    add_output_arguments(dataset_export_parser)
+    add_json_input_arguments(dataset_export_parser)
+    add_argument(dataset_export_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_export_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_export_parser, "data_set_id", required=True, help="Data set ID.")
+    dataset_export_parser.set_defaults(_parser=dataset_export_parser)
+    dataset_export_parser.set_defaults(handler=_handle_datasite_dataset_export)
+
+    dataset_import_parser = dataset_subparsers.add_parser("import", help="Import a data site data set from JSON payload.")
+    add_output_arguments(dataset_import_parser)
+    add_json_input_arguments(dataset_import_parser)
+    add_argument(dataset_import_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_import_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    dataset_import_parser.set_defaults(_parser=dataset_import_parser)
+    dataset_import_parser.set_defaults(handler=_handle_datasite_dataset_import)
+
+    dataset_files_parser = dataset_subparsers.add_parser("files", help="List files under a data site data set.")
+    add_output_arguments(dataset_files_parser)
+    add_argument(dataset_files_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_files_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_files_parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(dataset_files_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(dataset_files_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(dataset_files_parser, "order_by", required=False, default=None, help="Sort order, e.g. id:asc.")
+    dataset_files_parser.set_defaults(_parser=dataset_files_parser)
+    dataset_files_parser.set_defaults(handler=_handle_datasite_dataset_files)
+
+    dataset_download_files_parser = dataset_subparsers.add_parser(
+        "download-files",
+        help="Filter files in a data site data set, resolve DRS URLs, and download matching files.",
+    )
+    add_output_arguments(dataset_download_files_parser)
+    add_argument(dataset_download_files_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_download_files_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_download_files_parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(dataset_download_files_parser, "target", required=True, help="Local download directory.")
+    add_argument(dataset_download_files_parser, "page", required=False, type=int, default=1, help="Page number.")
+    add_argument(dataset_download_files_parser, "size", required=False, type=int, default=100, help="Page size.")
+    add_argument(dataset_download_files_parser, "order_by", required=False, default="id:asc", help="Sort order, e.g. id:asc.")
+    add_argument(dataset_download_files_parser, "name_contains", required=False, default=None, help="Case-insensitive substring filter on file name.")
+    add_argument(dataset_download_files_parser, "regex", required=False, default=None, help="Regular expression filter on file name.")
+    add_argument(dataset_download_files_parser, "drs_url", required=False, default=None, help="Optional exact DRS URL filter.")
+    add_argument(dataset_download_files_parser, "limit", required=False, type=int, default=None, help="Maximum number of matched files to download.")
+    add_bool_argument(
+        dataset_download_files_parser,
+        "dry_run",
+        default=False,
+        help_text="Preview matched files without downloading them.",
+    )
+    dataset_download_files_parser.set_defaults(_parser=dataset_download_files_parser)
+    dataset_download_files_parser.set_defaults(handler=_handle_datasite_dataset_download_files)
+
+    dataset_file_ids_parser = dataset_subparsers.add_parser("file-ids", help="List file IDs under a data site data set.")
+    add_output_arguments(dataset_file_ids_parser)
+    add_argument(dataset_file_ids_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_file_ids_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_file_ids_parser, "data_set_id", required=True, help="Data set ID.")
+    dataset_file_ids_parser.set_defaults(_parser=dataset_file_ids_parser)
+    dataset_file_ids_parser.set_defaults(handler=_handle_datasite_dataset_file_ids)
+
+    dataset_file_upsert_parser = dataset_subparsers.add_parser("upsert-files", help="Upsert files under a data site data set from JSON payload.")
+    add_output_arguments(dataset_file_upsert_parser)
+    add_json_input_arguments(dataset_file_upsert_parser)
+    add_argument(dataset_file_upsert_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_file_upsert_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_file_upsert_parser, "data_set_id", required=True, help="Data set ID.")
+    dataset_file_upsert_parser.set_defaults(_parser=dataset_file_upsert_parser)
+    dataset_file_upsert_parser.set_defaults(handler=_handle_datasite_dataset_files_upsert)
+
+    dataset_file_delete_parser = dataset_subparsers.add_parser("delete-files", help="Delete files under a data site data set using JSON payload.")
+    add_output_arguments(dataset_file_delete_parser)
+    add_json_input_arguments(dataset_file_delete_parser)
+    add_argument(dataset_file_delete_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(dataset_file_delete_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(dataset_file_delete_parser, "data_set_id", required=True, help="Data set ID.")
+    dataset_file_delete_parser.set_defaults(_parser=dataset_file_delete_parser)
+    dataset_file_delete_parser.set_defaults(handler=_handle_datasite_dataset_files_delete)
+
+    file_parser = datasite_subparsers.add_parser("file", help="Data site file commands.")
+    file_subparsers = file_parser.add_subparsers(dest="file_command")
+    file_parser.set_defaults(_parser=file_parser)
+
+    file_list_parser = file_subparsers.add_parser("list", help="List data site files.")
+    add_output_arguments(file_list_parser)
+    add_argument(file_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(file_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(file_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(file_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(file_list_parser, "order_by", required=False, default=None, help="Sort order, e.g. id:asc.")
+    file_list_parser.set_defaults(_parser=file_list_parser)
+    file_list_parser.set_defaults(handler=_handle_datasite_file_list)
+
+    file_types_parser = file_subparsers.add_parser("types", help="List data file types.")
+    add_output_arguments(file_types_parser)
+    add_argument(file_types_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(file_types_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    file_types_parser.set_defaults(_parser=file_types_parser)
+    file_types_parser.set_defaults(handler=_handle_datasite_file_types)
+
+    file_drs_parser = file_subparsers.add_parser("list-drs", help="List DRS URLs for files in a data set.")
+    add_output_arguments(file_drs_parser)
+    add_argument(file_drs_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(file_drs_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(file_drs_parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(file_drs_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(file_drs_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(file_drs_parser, "order_by", required=False, default=None, help="Sort order, e.g. id:asc.")
+    file_drs_parser.set_defaults(_parser=file_drs_parser)
+    file_drs_parser.set_defaults(handler=_handle_datasite_file_list_drs)
+
+    schema_job_parser = datasite_subparsers.add_parser("schema-job", help="Data site schema job commands.")
+    schema_job_subparsers = schema_job_parser.add_subparsers(dest="schema_job_command")
+    schema_job_parser.set_defaults(_parser=schema_job_parser)
+
+    schema_job_list_parser = schema_job_subparsers.add_parser("list", help="List schema jobs.")
+    add_output_arguments(schema_job_list_parser)
+    add_argument(schema_job_list_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_list_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_list_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_list_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_list_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_list_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    add_argument(schema_job_list_parser, "job_type", required=False, default=None, help="Optional job type filter.")
+    schema_job_list_parser.set_defaults(_parser=schema_job_list_parser)
+    schema_job_list_parser.set_defaults(handler=_handle_datasite_schema_job_list)
+
+    schema_job_export_parser = schema_job_subparsers.add_parser("export", help="List export schema jobs.")
+    add_output_arguments(schema_job_export_parser)
+    add_argument(schema_job_export_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_export_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_export_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_export_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_export_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_export_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    schema_job_export_parser.set_defaults(_parser=schema_job_export_parser)
+    schema_job_export_parser.set_defaults(handler=_handle_datasite_schema_job_export)
+
+    schema_job_import_parser = schema_job_subparsers.add_parser("import", help="List import schema jobs.")
+    add_output_arguments(schema_job_import_parser)
+    add_argument(schema_job_import_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_import_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_import_parser, "page", required=False, type=int, default=None, help="Page number.")
+    add_argument(schema_job_import_parser, "size", required=False, type=int, default=None, help="Page size.")
+    add_argument(schema_job_import_parser, "order_by", required=False, default="startTime:desc", help="Sort order.")
+    add_argument(schema_job_import_parser, "scope", required=False, action="append", help="Scope filter. Can be repeated.")
+    schema_job_import_parser.set_defaults(_parser=schema_job_import_parser)
+    schema_job_import_parser.set_defaults(handler=_handle_datasite_schema_job_import)
+
+    schema_job_delete_parser = schema_job_subparsers.add_parser("delete", help="Delete a schema job.")
+    add_output_arguments(schema_job_delete_parser)
+    add_argument(schema_job_delete_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(schema_job_delete_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(schema_job_delete_parser, "id", required=True, help="Schema job ID.")
+    schema_job_delete_parser.set_defaults(_parser=schema_job_delete_parser)
+    schema_job_delete_parser.set_defaults(handler=_handle_datasite_schema_job_delete)
+
+    drs_parser = datasite_subparsers.add_parser("drs", help="Data site DRS commands.")
+    drs_subparsers = drs_parser.add_subparsers(dest="drs_command")
+    drs_parser.set_defaults(_parser=drs_parser)
+
+    drs_object_parser = drs_subparsers.add_parser("object", help="Get a DRS object.")
+    add_output_arguments(drs_object_parser)
+    add_argument(drs_object_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_object_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_object_parser, "object_id", required=True, help="DRS object ID.")
+    drs_object_parser.set_defaults(_parser=drs_object_parser)
+    drs_object_parser.set_defaults(handler=_handle_datasite_drs_object)
+
+    drs_object_auth_parser = drs_subparsers.add_parser("object-auth", help="Post to a DRS object endpoint with JSON payload.")
+    add_output_arguments(drs_object_auth_parser)
+    add_json_input_arguments(drs_object_auth_parser)
+    add_argument(drs_object_auth_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_object_auth_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_object_auth_parser, "object_id", required=True, help="DRS object ID.")
+    drs_object_auth_parser.set_defaults(_parser=drs_object_auth_parser)
+    drs_object_auth_parser.set_defaults(handler=_handle_datasite_drs_object_auth)
+
+    drs_access_parser = drs_subparsers.add_parser("access", help="Get DRS access for an object.")
+    add_output_arguments(drs_access_parser)
+    add_argument(drs_access_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_access_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_access_parser, "object_id", required=True, help="DRS object ID.")
+    add_argument(drs_access_parser, "access_id", required=True, help="DRS access ID.")
+    drs_access_parser.set_defaults(_parser=drs_access_parser)
+    drs_access_parser.set_defaults(handler=_handle_datasite_drs_access)
+
+    drs_access_auth_parser = drs_subparsers.add_parser("access-auth", help="Post to a DRS access endpoint with JSON payload.")
+    add_output_arguments(drs_access_auth_parser)
+    add_json_input_arguments(drs_access_auth_parser)
+    add_argument(drs_access_auth_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_access_auth_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_access_auth_parser, "object_id", required=True, help="DRS object ID.")
+    add_argument(drs_access_auth_parser, "access_id", required=True, help="DRS access ID.")
+    drs_access_auth_parser.set_defaults(_parser=drs_access_auth_parser)
+    drs_access_auth_parser.set_defaults(handler=_handle_datasite_drs_access_auth)
+
+    drs_resolve_parser = drs_subparsers.add_parser("resolve", help="Resolve a DRS URL into object metadata and access details.")
+    add_output_arguments(drs_resolve_parser)
+    add_argument(drs_resolve_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_resolve_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_resolve_parser, "drs_url", required=True, help="DRS URL, for example drs://host/object-id.")
+    add_argument(drs_resolve_parser, "access_id", required=False, default=None, help="Optional access ID override.")
+    drs_resolve_parser.set_defaults(_parser=drs_resolve_parser)
+    drs_resolve_parser.set_defaults(handler=_handle_datasite_drs_resolve)
+
+    drs_download_parser = drs_subparsers.add_parser("download", help="Download a file from a DRS URL to a local path.")
+    add_output_arguments(drs_download_parser)
+    add_argument(drs_download_parser, "token", required=False, default=None, help="AAI token override.")
+    add_argument(drs_download_parser, "cookie", required=False, default=None, help="AAI session cookie override.")
+    add_argument(drs_download_parser, "drs_url", required=True, help="DRS URL, for example drs://host/object-id.")
+    add_argument(drs_download_parser, "target", required=True, help="Local file path or target directory.")
+    add_argument(drs_download_parser, "access_id", required=False, default=None, help="Optional access ID override.")
+    drs_download_parser.set_defaults(_parser=drs_download_parser)
+    drs_download_parser.set_defaults(handler=_handle_datasite_drs_download)
+
+
 def _add_ies_group(subparsers: Any) -> None:
     ies_parser = subparsers.add_parser("ies", help="IES application commands.")
     ies_subparsers = ies_parser.add_subparsers(dest="ies_command")
@@ -797,6 +1664,91 @@ def _handle_auth_status(args: argparse.Namespace) -> dict:
     return status
 
 
+def _save_client_auth(
+    *,
+    access_key: Optional[str],
+    secret_key: Optional[str],
+    endpoint: Optional[str],
+    region: Optional[str],
+    config_path: Optional[str],
+) -> list[dict]:
+    from bioos.cli.config_store import update_section_values
+
+    values = {}
+    if access_key:
+        values["MIRACLE_ACCESS_KEY"] = access_key
+    if secret_key:
+        values["MIRACLE_SECRET_KEY"] = secret_key
+    if endpoint:
+        values["serveraddr"] = endpoint
+    if region:
+        values["region"] = region
+    if not values:
+        return []
+
+    saved_path = update_section_values("client", values, path=config_path)
+    return [
+        {
+            "section": "client",
+            "config_path": str(saved_path),
+            "fields": sorted(values.keys()),
+        }
+    ]
+
+
+def _handle_auth_connect_aai(args: argparse.Namespace) -> dict:
+    saved = []
+    if getattr(args, "save_client", True):
+        settings = resolve_auth_settings(
+            access_key=getattr(args, "ak", None),
+            secret_key=getattr(args, "sk", None),
+            endpoint=getattr(args, "endpoint", None),
+            region=getattr(args, "region", None),
+        )
+        saved.extend(
+            _save_client_auth(
+                access_key=settings.get("access_key"),
+                secret_key=settings.get("secret_key"),
+                endpoint=settings.get("endpoint"),
+                region=settings.get("region"),
+                config_path=getattr(args, "config_path", None),
+            )
+        )
+
+    auth_status = _handle_auth_status(args)
+    if not auth_status.get("success"):
+        result = {
+            "saved": saved,
+            "auth": auth_status,
+            "synced": False,
+        }
+        return result
+
+    aai_args = argparse.Namespace(
+        account_name=getattr(args, "account_name", None),
+        password=getattr(args, "password", None),
+        user_name=getattr(args, "user_name", None),
+        web_url=getattr(args, "web_url", None),
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        curl=getattr(args, "curl", None),
+        curl_file=getattr(args, "curl_file", None),
+        save_main_web=getattr(args, "save_main_web", True),
+        sync_passport=getattr(args, "sync_passport", True),
+        expires_in=getattr(args, "expires_in", None),
+        config_path=getattr(args, "config_path", None),
+    )
+    aai_result = _handle_aai_login(aai_args)
+
+    return {
+        "saved": saved + (aai_result.get("saved") or []),
+        "auth": auth_status,
+        "aai": aai_result,
+        "synced": bool(aai_result.get("synced")),
+    }
+
+
 def _handle_config_path(_: argparse.Namespace) -> dict:
     config_path = get_config_path()
     return {
@@ -812,12 +1764,1223 @@ def _handle_config_example(_: argparse.Namespace) -> dict:
     }
 
 
+def _handle_aai_auth(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import resolve_aai_with_args
+
+    settings = resolve_aai_with_args(args, service=getattr(args, "service", "repo"))
+    return {
+        "service": settings["service"],
+        "configured": bool(settings.get("url")),
+        "authenticated": bool(settings.get("token") or settings.get("cookie")),
+        "url_source": settings["url_source"],
+        "url": settings["url"],
+        "token_source": settings["token_source"],
+        "token": _mask_value(settings["token"]),
+        "cookie_source": settings["cookie_source"],
+        "cookie_configured": bool(settings.get("cookie")),
+        "passport_issued_at": settings.get("passport_issued_at"),
+        "passport_expires_at": settings.get("passport_expires_at"),
+        "passport_status": settings.get("passport_status"),
+        "config_path": settings["config_path"],
+    }
+
+
+def _handle_aai_status(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import resolve_aai_settings, resolve_main_web_settings
+
+    main_web = resolve_main_web_settings(
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        url=getattr(args, "web_url", None),
+    )
+    repo = resolve_aai_settings(service="repo")
+    datasite = resolve_aai_settings(service="datasite")
+    return {
+        "main_web": {
+            "url": main_web["url"],
+            "url_source": main_web["url_source"],
+            "login_token_source": main_web["login_token_source"],
+            "login_token_configured": bool(main_web.get("login_token")),
+            "csrf_token_source": main_web["csrf_token_source"],
+            "csrf_token_configured": bool(main_web.get("csrf_token")),
+            "cookie_source": main_web["cookie_source"],
+            "cookie_configured": bool(main_web.get("cookie")),
+        },
+        "repo": {
+            "url": repo["url"],
+            "url_source": repo["url_source"],
+            "token_source": repo["token_source"],
+            "token_configured": bool(repo.get("token")),
+            "cookie_source": repo["cookie_source"],
+            "cookie_configured": bool(repo.get("cookie")),
+            "passport_issued_at": repo.get("passport_issued_at"),
+            "passport_expires_at": repo.get("passport_expires_at"),
+            "passport_status": repo.get("passport_status"),
+        },
+        "datasite": {
+            "url": datasite["url"],
+            "url_source": datasite["url_source"],
+            "token_source": datasite["token_source"],
+            "token_configured": bool(datasite.get("token")),
+            "cookie_source": datasite["cookie_source"],
+            "cookie_configured": bool(datasite.get("cookie")),
+            "passport_issued_at": datasite.get("passport_issued_at"),
+            "passport_expires_at": datasite.get("passport_expires_at"),
+            "passport_status": datasite.get("passport_status"),
+        },
+    }
+
+
+def _handle_aai_import_main_web_curl(args: argparse.Namespace) -> dict:
+    curl_text = getattr(args, "curl", None)
+    curl_file = getattr(args, "curl_file", None)
+    if bool(curl_text) == bool(curl_file):
+        raise ValueError("Use exactly one of --curl or --curl-file.")
+    if curl_file:
+        from pathlib import Path
+
+        curl_text = Path(curl_file).read_text(encoding="utf-8")
+    if not curl_text:
+        raise ValueError("Missing cURL input.")
+
+    url_match = re.search(r"curl\s+'([^']+)'", curl_text)
+    login_token_match = re.search(r"-H\s+'x-logintoken:\s*([^']+)'", curl_text, flags=re.IGNORECASE)
+    csrf_match = re.search(r"-H\s+'x-csrf-token:\s*([^']+)'", curl_text, flags=re.IGNORECASE)
+    cookie_match = re.search(r"-b\s+'([^']+)'", curl_text)
+
+    web_url = None
+    if url_match:
+        url_value = url_match.group(1)
+        parts = url_value.split("/", 3)
+        if len(parts) >= 3:
+            web_url = f"{parts[0]}//{parts[2]}"
+
+    return {
+        "web_url": web_url,
+        "login_token": login_token_match.group(1).strip() if login_token_match else None,
+        "login_token_masked": _mask_value(login_token_match.group(1).strip()) if login_token_match else None,
+        "csrf_token": csrf_match.group(1).strip() if csrf_match else None,
+        "csrf_token_masked": _mask_value(csrf_match.group(1).strip()) if csrf_match else None,
+        "cookie": cookie_match.group(1).strip() if cookie_match else None,
+        "cookie_configured": bool(cookie_match),
+    }
+
+
+def _extract_main_web_auth_from_args(args: argparse.Namespace) -> dict:
+    import_args = argparse.Namespace(
+        curl=getattr(args, "curl", None),
+        curl_file=getattr(args, "curl_file", None),
+    )
+    return _handle_aai_import_main_web_curl(import_args)
+
+
+def _resolve_main_web_auth_inputs(args: argparse.Namespace) -> dict:
+    has_password_auth = bool(getattr(args, "account_name", None) and getattr(args, "password", None))
+    has_direct_auth = any(
+        getattr(args, name, None)
+        for name in ("login_token", "csrf_token", "cookie")
+    )
+    has_web_url_override = bool(getattr(args, "web_url", None))
+    has_curl_auth = bool(getattr(args, "curl", None) or getattr(args, "curl_file", None))
+
+    selected_modes = sum(bool(flag) for flag in (has_password_auth, has_direct_auth, has_curl_auth))
+    if selected_modes > 1:
+        raise ValueError("Use only one main-web auth source: password login, direct auth flags, or --curl/--curl-file.")
+    if has_curl_auth and has_web_url_override:
+        raise ValueError("Do not combine --web-url with --curl/--curl-file. The web URL is derived from the cURL input.")
+
+    if has_password_auth:
+        from bioos.ops.auth import login_to_main_web
+
+        auth = login_to_main_web(
+            account_name=getattr(args, "account_name"),
+            password=getattr(args, "password"),
+            user_name=getattr(args, "user_name", None),
+            url=getattr(args, "web_url", None),
+        )
+        return {
+            "web_url": auth.get("web_url"),
+            "login_token": auth.get("login_token"),
+            "csrf_token": auth.get("csrf_token"),
+            "cookie": auth.get("cookie"),
+            "source": "password",
+            "extracted": {
+                "web_url": auth.get("web_url"),
+                "login_token_masked": _mask_value(auth.get("login_token")),
+                "csrf_token_masked": _mask_value(auth.get("csrf_token")),
+                "cookie_configured": bool(auth.get("cookie")),
+                "login_result": {
+                    "account_name": auth.get("login_result", {}).get("AccountName") if isinstance(auth.get("login_result"), dict) else None,
+                    "email": auth.get("login_result", {}).get("Email") if isinstance(auth.get("login_result"), dict) else None,
+                    "role": auth.get("login_result", {}).get("Role") if isinstance(auth.get("login_result"), dict) else None,
+                },
+            },
+        }
+
+    if has_curl_auth:
+        extracted = _extract_main_web_auth_from_args(args)
+        return {
+            "web_url": extracted.get("web_url"),
+            "login_token": extracted.get("login_token"),
+            "csrf_token": extracted.get("csrf_token"),
+            "cookie": extracted.get("cookie"),
+            "source": "curl",
+            "extracted": {
+                "web_url": extracted.get("web_url"),
+                "login_token_masked": extracted.get("login_token_masked"),
+                "csrf_token_masked": extracted.get("csrf_token_masked"),
+                "cookie_configured": extracted.get("cookie_configured"),
+            },
+        }
+
+    return {
+        "web_url": getattr(args, "web_url", None),
+        "login_token": getattr(args, "login_token", None),
+        "csrf_token": getattr(args, "csrf_token", None),
+        "cookie": getattr(args, "cookie", None),
+        "source": "direct",
+        "extracted": None,
+    }
+
+
+def _save_main_web_auth(
+    *,
+    web_url: Optional[str],
+    login_token: Optional[str],
+    csrf_token: Optional[str],
+    cookie: Optional[str],
+    config_path: Optional[str],
+) -> list[dict]:
+    from bioos.cli.config_store import update_section_values
+
+    values = {}
+    if web_url:
+        values["url"] = web_url
+    if login_token:
+        values["login_token"] = login_token
+    if csrf_token:
+        values["csrf_token"] = csrf_token
+    if cookie:
+        values["cookie"] = cookie
+    if not values:
+        return []
+
+    saved_path = update_section_values("main_web", values, path=config_path)
+    return [
+        {
+            "section": "main_web",
+            "config_path": str(saved_path),
+            "fields": sorted(values.keys()),
+        }
+    ]
+
+
+def _handle_account_link(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import resolve_account_link_settings
+
+    return resolve_account_link_settings(path=getattr(args, "config_path", None))
+
+
+def _handle_aai_account_status(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_main_web_client, resolve_main_web_settings
+
+    settings = resolve_main_web_settings(
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        url=getattr(args, "web_url", None),
+    )
+    client = build_main_web_client(
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        url=getattr(args, "web_url", None),
+    )
+    result = client.check_repository_account_exist()
+    return {
+        "web_url": settings["url"],
+        "web_url_source": settings["url_source"],
+        "login_token_source": settings["login_token_source"],
+        "csrf_token_source": settings["csrf_token_source"],
+        "cookie_source": settings["cookie_source"],
+        "linked": _is_repository_account_linked(result),
+        "result": result,
+    }
+
+
+def _handle_aai_passport_get(args: argparse.Namespace) -> dict:
+    from bioos.cli.config_store import update_section_values
+    from bioos.ops.auth import build_main_web_client, resolve_main_web_settings
+
+    settings = resolve_main_web_settings(
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        url=getattr(args, "web_url", None),
+    )
+    client = build_main_web_client(
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        url=getattr(args, "web_url", None),
+    )
+    result = client.get_repository_passport(expires_in=getattr(args, "expires_in", None))
+    passport = result.get("Passport") if isinstance(result, dict) else None
+    issued_at, expires_at = _compute_passport_timestamps(getattr(args, "expires_in", None))
+    save_targets = getattr(args, "save_to", None) or []
+    saved = []
+    if passport:
+        for target in save_targets:
+            normalized = (target or "").strip().lower()
+            if normalized not in {"repo", "datasite"}:
+                raise ValueError(f"Unsupported save target: {target}. Expected repo and/or datasite.")
+            config_path = update_section_values(
+                normalized,
+                {
+                    "token": passport,
+                    "passport_issued_at": issued_at,
+                    "passport_expires_at": expires_at,
+                },
+                path=getattr(args, "config_path", None),
+            )
+            saved.append(
+                {
+                    "section": normalized,
+                    "config_path": str(config_path),
+                }
+            )
+    return {
+        "web_url": settings["url"],
+        "web_url_source": settings["url_source"],
+        "login_token_source": settings["login_token_source"],
+        "csrf_token_source": settings["csrf_token_source"],
+        "cookie_source": settings["cookie_source"],
+        "passport": passport,
+        "passport_masked": _mask_value(passport),
+        "passport_issued_at": issued_at,
+        "passport_expires_at": expires_at,
+        "saved": saved,
+        "result": result,
+    }
+
+
+def _handle_aai_sync_from_bioos(args: argparse.Namespace) -> dict:
+    sync_args = argparse.Namespace(
+        web_url=getattr(args, "web_url", None),
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        expires_in=getattr(args, "expires_in", None),
+        save_to=["repo", "datasite"],
+        config_path=getattr(args, "config_path", None),
+    )
+    result = _handle_aai_passport_get(sync_args)
+    result["synced"] = True
+    return result
+
+
+def _handle_aai_sync_from_curl(args: argparse.Namespace) -> dict:
+    extracted = _extract_main_web_auth_from_args(args)
+    sync_args = argparse.Namespace(
+        web_url=extracted.get("web_url"),
+        login_token=extracted.get("login_token"),
+        csrf_token=extracted.get("csrf_token"),
+        cookie=extracted.get("cookie"),
+        expires_in=getattr(args, "expires_in", None),
+        config_path=getattr(args, "config_path", None),
+    )
+    result = _handle_aai_sync_from_bioos(sync_args)
+    result["extracted"] = {
+        "web_url": extracted.get("web_url"),
+        "login_token_masked": extracted.get("login_token_masked"),
+        "csrf_token_masked": extracted.get("csrf_token_masked"),
+        "cookie_configured": extracted.get("cookie_configured"),
+    }
+    return result
+
+
+def _handle_aai_login(args: argparse.Namespace) -> dict:
+    resolved = _resolve_main_web_auth_inputs(args)
+    save_main_web = getattr(args, "save_main_web", True)
+    sync_passport = getattr(args, "sync_passport", True)
+
+    saved = []
+    if save_main_web:
+        saved.extend(
+            _save_main_web_auth(
+                web_url=resolved.get("web_url"),
+                login_token=resolved.get("login_token"),
+                csrf_token=resolved.get("csrf_token"),
+                cookie=resolved.get("cookie"),
+                config_path=getattr(args, "config_path", None),
+            )
+        )
+
+    result = {
+        "mode": resolved["source"],
+        "saved": saved,
+        "main_web": {
+            "web_url": resolved.get("web_url"),
+            "login_token_configured": bool(resolved.get("login_token")),
+            "csrf_token_configured": bool(resolved.get("csrf_token")),
+            "cookie_configured": bool(resolved.get("cookie")),
+        },
+        "synced": False,
+    }
+
+    if resolved.get("extracted"):
+        result["extracted"] = resolved["extracted"]
+
+    if not sync_passport:
+        return result
+
+    link_status = _handle_aai_account_status(
+        argparse.Namespace(
+            web_url=resolved.get("web_url"),
+            login_token=resolved.get("login_token"),
+            csrf_token=resolved.get("csrf_token"),
+            cookie=resolved.get("cookie"),
+        )
+    )
+    result["account_link"] = link_status
+    if not link_status.get("linked"):
+        result["message"] = (
+            "The current BioOS web account is not linked to an AAI repository account. "
+            "Link the account first, then run 'bioos aai login' again."
+        )
+        return result
+
+    sync_args = argparse.Namespace(
+        web_url=resolved.get("web_url"),
+        login_token=resolved.get("login_token"),
+        csrf_token=resolved.get("csrf_token"),
+        cookie=resolved.get("cookie"),
+        expires_in=getattr(args, "expires_in", None),
+        config_path=getattr(args, "config_path", None),
+    )
+    sync_result = _handle_aai_sync_from_bioos(sync_args)
+    result.update(sync_result)
+    if saved:
+        passport_saved = sync_result.get("saved") or []
+        result["saved"] = saved + passport_saved
+    return result
+
+
+def _handle_aai_refresh(args: argparse.Namespace) -> dict:
+    refresh_args = argparse.Namespace(
+        account_name=getattr(args, "account_name", None),
+        password=getattr(args, "password", None),
+        user_name=getattr(args, "user_name", None),
+        web_url=getattr(args, "web_url", None),
+        login_token=getattr(args, "login_token", None),
+        csrf_token=getattr(args, "csrf_token", None),
+        cookie=getattr(args, "cookie", None),
+        curl=getattr(args, "curl", None),
+        curl_file=getattr(args, "curl_file", None),
+        save_main_web=getattr(args, "save_main_web", True),
+        sync_passport=True,
+        expires_in=getattr(args, "expires_in", None),
+        config_path=getattr(args, "config_path", None),
+    )
+    result = _handle_aai_login(refresh_args)
+    result["refreshed"] = bool(result.get("synced"))
+    return result
+
+
+def _handle_repo_dataset_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_datasets(
+        page=args.page,
+        size=args.size,
+        display_level=args.display_level,
+        order_by=args.order_by,
+    )
+
+
+def _handle_repo_dataset_get(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_dataset(args.id)
+
+
+def _handle_repo_dataset_export(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.export_dataset(args.data_set_id, payload=load_json_input(args))
+
+
+def _handle_repo_dataset_import(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.import_dataset(load_json_input(args))
+
+
+def _handle_repo_dataset_archive_access(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_dataset_archive_access(path=args.path)
+
+
+def _handle_repo_dataset_files(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dataset_files(args.data_set_id, page=args.page, size=args.size, order_by=args.order_by)
+
+
+def _handle_repo_dataset_file_ids(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dataset_file_ids(args.data_set_id)
+
+
+def _handle_repo_dac_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dacs(page=args.page, size=args.size, limit=args.limit, scope=args.scope)
+
+
+def _handle_repo_dac_create(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.create_dac(load_json_input(args))
+
+
+def _handle_repo_dac_update(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.update_dac(args.id, load_json_input(args))
+
+
+def _handle_repo_dac_delete(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.delete_dac(args.id)
+
+
+def _handle_repo_dac_check(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.check_dac(name=args.name)
+
+
+def _handle_repo_dac_member_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dac_members(args.dac_id, page=args.page, size=args.size)
+
+
+def _handle_repo_dac_member_upsert(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.upsert_dac_member(args.dac_id, load_json_input(args))
+
+
+def _handle_repo_dac_member_remove(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.remove_dac_member(args.dac_id, load_json_input(args))
+
+
+def _handle_repo_application_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_applications(
+        page=args.page,
+        size=args.size,
+        app_type=args.app_type,
+        field=args.field,
+        show_pending_approval=args.show_pending_approval,
+    )
+
+
+def _handle_repo_library_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_libraries()
+
+
+def _handle_repo_schema_job_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_schema_jobs(
+        page=args.page,
+        size=args.size,
+        order_by=args.order_by,
+        scope=args.scope,
+        job_type=args.job_type,
+    )
+
+
+def _handle_repo_schema_job_export(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_export_schema_jobs(page=args.page, size=args.size, order_by=args.order_by, scope=args.scope)
+
+
+def _handle_repo_schema_job_import(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_import_schema_jobs(page=args.page, size=args.size, order_by=args.order_by, scope=args.scope)
+
+
+def _handle_repo_data_site_pre_signed_url(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_datasite_pre_signed_url(args.filename)
+
+
+def _handle_repo_pylons_admins(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_admins()
+
+
+def _handle_repo_pylons_organization_names(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_organization_names(args.id)
+
+
+def _handle_repo_pylons_identity(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_repository_client
+
+    client = build_repository_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_identity(args.id)
+
+
+def _handle_datasite_application_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_applications(page=args.page, size=args.size)
+
+
+def _handle_datasite_application_permit(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.permit_application(args.id, args.task_id)
+
+
+def _handle_datasite_application_reject(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.reject_application(args.id, args.task_id)
+
+
+def _handle_datasite_dataset_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_datasets(
+        page=args.page,
+        size=args.size,
+        tab=args.tab,
+        display_level=args.display_level,
+        order_by=args.order_by,
+    )
+
+
+def _handle_datasite_dataset_get(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_dataset(args.id)
+
+
+def _handle_datasite_dataset_template(args: argparse.Namespace) -> dict:
+    kind = (getattr(args, "kind", None) or "create").strip().lower()
+    templates = {
+        "create": {
+            "name": "mc-dataset-demo",
+            "description": "Demo data set created from pybioos CLI.",
+            "createTime": 1778112000,
+            "updateTime": 1778112000,
+            "owners": "BioOS Team",
+            "category": "Genomics",
+            "catalogue": "Human omics",
+            "labels": ["WGS", "Cancer"],
+            "docURL": "https://example.org/docs/mc-dataset-demo",
+            "emails": ["owner@example.org"],
+            "licence": "CC-BY-4.0",
+            "projectDataTypes": ["FASTQ", "BAM"],
+            "sampleScope": "Human cohort",
+            "externalLink": "https://example.org/project/mc-dataset-demo",
+            "externalLinkDescription": "Project home page",
+            "exampleTutorial": "https://example.org/tutorials/mc-dataset-demo",
+            "tools": "https://example.org/tools/mc-dataset-demo",
+            "publications": [
+                {
+                    "name": "Example publication",
+                    "accessURL": "https://doi.org/10.1000/example",
+                    "authors": "Alice Zhang; Bob Li",
+                    "quotation": "Zhang A, Li B. Example dataset paper. 2025.",
+                }
+            ],
+            "dataFilesAccessURL": "https://example.org/downloads/mc-dataset-demo/files.csv",
+            "dataSetAccessMethodURL": "https://example.org/downloads/mc-dataset-demo/access_methods.json",
+            "dataSetTablesAccessURL": {
+                "sample_sheet": "https://example.org/downloads/mc-dataset-demo/sample_sheet.tsv"
+            },
+        },
+        "apply": {
+            "type": "DataSetCreate",
+            "dataSetID": "replace-with-created-data-set-id",
+            "title": "Publish mc-dataset-demo to data site",
+            "reason": "Initial release from pybioos workflow.",
+        },
+        "upsert-files": {
+            "dataFiles": [
+                {
+                    "name": "example_01.fastq.gz",
+                    "description": "Paired-end read 1",
+                    "createTime": 1778112000,
+                    "updateTime": 1778112000,
+                    "fileType": "FASTQ",
+                    "fileSize": 123456789,
+                    "accessURL": "s3://bucket/path/example_01.fastq.gz",
+                    "source": "s3://bucket/path/example_01.fastq.gz",
+                    "checksums": [
+                        {
+                            "type": "md5",
+                            "value": "d41d8cd98f00b204e9800998ecf8427e",
+                        }
+                    ],
+                }
+            ],
+            "duplicatedReplace": True,
+        },
+        "release": {
+            "comment": "Release approved and ready for publication."
+        },
+        "update-config": {
+            "customHeaderOrders": {
+                "sample_id": "1",
+                "subject_id": "2",
+                "tumor_type": "3",
+            }
+        },
+        "delete-files": {
+            "dataFileIDs": ["replace-with-file-id-1", "replace-with-file-id-2"]
+        },
+    }
+    if kind not in templates:
+        raise ValueError("Unsupported template kind. Expected create, apply, upsert-files, release, update-config, or delete-files.")
+    return {
+        "kind": kind,
+        "template": templates[kind],
+    }
+
+
+def _handle_datasite_dataset_create(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.create_dataset(load_json_input(args))
+
+
+def _handle_datasite_dataset_apply(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.apply_dataset(load_json_input(args))
+
+
+def _handle_datasite_dataset_update(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.update_dataset(args.id, load_json_input(args))
+
+
+def _handle_datasite_dataset_update_config(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.update_dataset_config(args.id, load_json_input(args))
+
+
+def _handle_datasite_dataset_delete(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.delete_dataset(args.id)
+
+
+def _handle_datasite_dataset_permission(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_dataset_permission(args.id)
+
+
+def _handle_datasite_dataset_release(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.release_dataset(args.id, payload=load_json_input(args))
+
+
+def _handle_datasite_dataset_revoke(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.revoke_dataset(args.id, payload=load_json_input(args))
+
+
+def _handle_datasite_dataset_check(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.check_dataset(name=args.name)
+
+
+def _handle_datasite_dataset_archive_access(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_dataset_archive_access(path=args.path)
+
+
+def _handle_datasite_dataset_export(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.export_dataset(args.data_set_id, payload=load_json_input(args))
+
+
+def _handle_datasite_dataset_import(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.import_dataset(load_json_input(args))
+
+
+def _handle_datasite_dataset_files(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dataset_files(args.data_set_id, page=args.page, size=args.size, order_by=args.order_by)
+
+
+def _handle_datasite_dataset_download_files(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    result = client.list_dataset_files(args.data_set_id, page=args.page, size=args.size, order_by=args.order_by)
+    items = result.get("items") if isinstance(result, dict) else None
+    if not isinstance(items, list):
+        return {
+            "data_set_id": args.data_set_id,
+            "matched_count": 0,
+            "downloaded_count": 0,
+            "items": [],
+            "source": result,
+        }
+
+    matched = _filter_datasite_file_items(
+        items=items,
+        name_contains=getattr(args, "name_contains", None),
+        regex_pattern=getattr(args, "regex", None),
+        exact_drs_url=getattr(args, "drs_url", None),
+        limit=getattr(args, "limit", None),
+    )
+    target_dir = Path(args.target).expanduser()
+    downloads = []
+    for item in matched:
+        file_name = item.get("name")
+        drs_url = item.get("drs_url")
+        download_item = {
+            "id": item.get("id"),
+            "name": file_name,
+            "drs_url": drs_url,
+        }
+        if not getattr(args, "dry_run", False):
+            resolved = _resolve_drs_download_info(
+                client=client,
+                drs_url=drs_url,
+                access_id=None,
+            )
+            access_url = resolved.get("access_url")
+            if not access_url:
+                raise ValueError(f"Failed to resolve downloadable access URL for DRS {drs_url}.")
+            output_path = _determine_download_target(
+                target=str(target_dir),
+                file_name=resolved.get("file_name") or file_name,
+                access_url=access_url,
+            )
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            urllib.request.urlretrieve(access_url, output_path)
+            download_item["output_path"] = str(output_path)
+            download_item["access_url"] = access_url
+        downloads.append(download_item)
+
+    return {
+        "data_set_id": args.data_set_id,
+        "matched_count": len(matched),
+        "downloaded_count": 0 if getattr(args, "dry_run", False) else len(downloads),
+        "dry_run": bool(getattr(args, "dry_run", False)),
+        "target": str(target_dir),
+        "items": downloads,
+    }
+
+
+def _handle_datasite_dataset_file_ids(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_dataset_file_ids(args.data_set_id)
+
+
+def _handle_datasite_dataset_files_upsert(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.upsert_dataset_files(args.data_set_id, load_json_input(args))
+
+
+def _handle_datasite_dataset_files_delete(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.delete_dataset_files(args.data_set_id, load_json_input(args))
+
+
+def _handle_datasite_file_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_files(page=args.page, size=args.size, order_by=args.order_by)
+
+
+def _handle_datasite_file_list_drs(args: argparse.Namespace) -> dict:
+    result = _handle_datasite_dataset_files(args)
+    items = result.get("items") if isinstance(result, dict) else None
+    if not isinstance(items, list):
+        return {"items": [], "source": result}
+    drs_items = []
+    for item in items:
+        if isinstance(item, dict):
+            drs_url = item.get("drsURL") or item.get("drs_url")
+            if drs_url:
+                drs_items.append(
+                    {
+                        "id": item.get("id"),
+                        "name": item.get("name"),
+                        "drs_url": drs_url,
+                    }
+                )
+    return {
+        "count": len(drs_items),
+        "items": drs_items,
+    }
+
+
+def _handle_datasite_file_types(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_file_types()
+
+
+def _handle_datasite_schema_job_list(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.list_schema_jobs(
+        page=args.page,
+        size=args.size,
+        order_by=args.order_by,
+        scope=args.scope,
+        job_type=args.job_type,
+    )
+
+
+def _handle_datasite_schema_job_export(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_export_schema_jobs(page=args.page, size=args.size, order_by=args.order_by, scope=args.scope)
+
+
+def _handle_datasite_schema_job_import(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_import_schema_jobs(page=args.page, size=args.size, order_by=args.order_by, scope=args.scope)
+
+
+def _handle_datasite_schema_job_delete(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.delete_schema_job(args.id)
+
+
+def _handle_datasite_drs_object(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_drs_object(args.object_id)
+
+
+def _handle_datasite_drs_object_auth(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.post_drs_object(args.object_id, load_json_input(args))
+
+
+def _handle_datasite_drs_access(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.get_drs_access(args.object_id, args.access_id)
+
+
+def _handle_datasite_drs_access_auth(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    return client.post_drs_access(args.object_id, args.access_id, load_json_input(args))
+
+
+def _handle_datasite_drs_resolve(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    resolved = _resolve_drs_download_info(
+        client=client,
+        drs_url=args.drs_url,
+        access_id=getattr(args, "access_id", None),
+    )
+    return {
+        "drs_url": args.drs_url,
+        "object_id": resolved["object_id"],
+        "selected_access_id": resolved.get("selected_access_id"),
+        "access_url": resolved.get("access_url"),
+        "file_name": resolved.get("file_name"),
+        "object": resolved.get("object"),
+        "access": resolved.get("access"),
+    }
+
+
+def _handle_datasite_drs_download(args: argparse.Namespace) -> dict:
+    from bioos.ops.auth import build_datasite_client
+
+    client = build_datasite_client(token=getattr(args, "token", None), cookie=getattr(args, "cookie", None))
+    resolved = _resolve_drs_download_info(
+        client=client,
+        drs_url=args.drs_url,
+        access_id=getattr(args, "access_id", None),
+    )
+    access_url = resolved.get("access_url")
+    if not access_url:
+        raise ValueError("Failed to resolve a downloadable HTTPS access URL from the DRS object.")
+    output_path = _determine_download_target(
+        target=args.target,
+        file_name=resolved.get("file_name"),
+        access_url=access_url,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(access_url, output_path)
+    return {
+        "success": True,
+        "drs_url": args.drs_url,
+        "object_id": resolved["object_id"],
+        "selected_access_id": resolved.get("selected_access_id"),
+        "access_url": access_url,
+        "output_path": str(output_path),
+        "file_name": output_path.name,
+    }
+
+
 def _mask_value(value: Optional[str]) -> Optional[str]:
     if not value:
         return None
     if len(value) <= 6:
         return "*" * len(value)
     return f"{value[:4]}...{value[-2:]}"
+
+
+def _is_repository_account_linked(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    exist_value = result.get("Exist")
+    if isinstance(exist_value, bool):
+        return exist_value
+    if exist_value is not None:
+        return str(exist_value).strip().lower() in {"1", "true", "yes"}
+    email = result.get("Email")
+    organizations = result.get("Organizations")
+    return bool(email or organizations)
+
+
+def _compute_passport_timestamps(expires_in: Optional[int]) -> tuple[Optional[str], Optional[str]]:
+    if not expires_in:
+        return None, None
+    issued_at = datetime.now(timezone.utc)
+    expires_at = issued_at + timedelta(seconds=expires_in)
+    return issued_at.isoformat(), expires_at.isoformat()
+
+
+def _parse_drs_url(drs_url: str) -> tuple[str, str]:
+    parsed = urlparse(drs_url)
+    if parsed.scheme != "drs":
+        raise ValueError(f"Unsupported DRS URL: {drs_url}")
+    object_id = parsed.path.lstrip("/")
+    if not object_id:
+        raise ValueError(f"Missing object ID in DRS URL: {drs_url}")
+    return parsed.netloc, object_id
+
+
+def _resolve_drs_download_info(client: Any, drs_url: str, access_id: Optional[str] = None) -> dict:
+    _, object_id = _parse_drs_url(drs_url)
+    obj = client.get_drs_object(object_id)
+    access_url = None
+    selected_access_id = access_id
+    access_result = None
+
+    if isinstance(obj, dict):
+        access_url = _extract_access_url(obj)
+        if not selected_access_id:
+            selected_access_id = _select_access_id(obj)
+        if not access_url and selected_access_id:
+            access_result = client.get_drs_access(object_id, selected_access_id)
+            access_url = _extract_access_url(access_result)
+
+    return {
+        "object_id": object_id,
+        "selected_access_id": selected_access_id,
+        "access_url": access_url,
+        "file_name": _extract_drs_file_name(obj, drs_url, access_url),
+        "object": obj,
+        "access": access_result,
+    }
+
+
+def _select_access_id(obj: dict) -> Optional[str]:
+    methods = obj.get("access_methods") or obj.get("accessMethods") or []
+    if not isinstance(methods, list):
+        return None
+    for method in methods:
+        if isinstance(method, dict):
+            access_id = method.get("access_id") or method.get("accessId")
+            if access_id:
+                return access_id
+    return None
+
+
+def _extract_access_url(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    for key in ("url", "access_url", "accessUrl"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.startswith(("http://", "https://")):
+            return value
+    methods = payload.get("access_methods") or payload.get("accessMethods") or []
+    if isinstance(methods, list):
+        for method in methods:
+            if isinstance(method, dict):
+                for key in ("access_url", "accessUrl"):
+                    value = method.get(key)
+                    if isinstance(value, str) and value.startswith(("http://", "https://")):
+                        return value
+    access_urls = payload.get("access_urls") or payload.get("accessURLs")
+    if isinstance(access_urls, dict):
+        for value in access_urls.values():
+            if isinstance(value, str) and value.startswith(("http://", "https://")):
+                return value
+    return None
+
+
+def _extract_drs_file_name(obj: Any, drs_url: str, access_url: Optional[str]) -> str:
+    if isinstance(obj, dict):
+        for key in ("name", "fileName", "filename"):
+            value = obj.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    if access_url:
+        access_path = urlparse(access_url).path
+        basename = Path(access_path).name
+        if basename:
+            return basename
+    return _parse_drs_url(drs_url)[1]
+
+
+def _determine_download_target(target: str, file_name: Optional[str], access_url: Optional[str]) -> Path:
+    target_path = Path(target).expanduser()
+    if target.endswith("/") or target_path.is_dir():
+        chosen_name = file_name or "downloaded-file"
+        return target_path / chosen_name
+    if not target_path.suffix and not target_path.exists():
+        guessed_name = file_name or (Path(urlparse(access_url or "").path).name if access_url else None)
+        if guessed_name:
+            return target_path / guessed_name
+    return target_path
+
+
+def _filter_datasite_file_items(
+    *,
+    items: list[Any],
+    name_contains: Optional[str],
+    regex_pattern: Optional[str],
+    exact_drs_url: Optional[str],
+    limit: Optional[int],
+) -> list[dict]:
+    regex = re.compile(regex_pattern) if regex_pattern else None
+    substring = name_contains.lower() if name_contains else None
+    matched: list[dict] = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "")
+        drs_url = item.get("drsURL") or item.get("drs_url")
+        if not drs_url:
+            continue
+        if substring and substring not in name.lower():
+            continue
+        if regex and not regex.search(name):
+            continue
+        if exact_drs_url and drs_url != exact_drs_url:
+            continue
+        matched.append(
+            {
+                "id": item.get("id"),
+                "name": name,
+                "drs_url": drs_url,
+            }
+        )
+        if limit is not None and len(matched) >= limit:
+            break
+    return matched
 
 
 

--- a/bioos/ops/auth.py
+++ b/bioos/ops/auth.py
@@ -1,7 +1,18 @@
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
-from bioos.cli.config_store import get_config_path, load_client_config
+from bioos.cli.config_store import (
+    get_config_path,
+    load_account_config,
+    load_client_config,
+    load_datasite_config,
+    load_main_web_config,
+    load_repo_config,
+)
+from bioos.service.main_web import MainWebClient
+from bioos.service.datasite import DataSiteClient
+from bioos.service.repository import RepositoryClient
 
 DEFAULT_ENDPOINT = "https://bio-top.miracle.ac.cn"
 
@@ -43,6 +54,106 @@ def resolve_auth_settings(
         "secret_key_source": secret_key_source,
         "endpoint_source": endpoint_source,
         "region_source": region_source,
+        "config_path": str(get_config_path()),
+    }
+
+
+def resolve_aai_settings(token: Optional[str] = None, cookie: Optional[str] = None, service: str = "repo") -> Dict[str, Optional[str]]:
+    normalized_service = _normalize_aai_service(service)
+    service_config = load_repo_config() if normalized_service == "repo" else load_datasite_config()
+    resolved_token, token_source = _resolve_value(
+        explicit_value=token,
+        env_names=(f"BIOOS_{normalized_service.upper()}_TOKEN", "BIOOS_AAI_TOKEN", "MIRACLE_AAI_TOKEN"),
+        config_values=(service_config.get("token"), service_config.get("access_token"), service_config.get("session")),
+    )
+    resolved_cookie, cookie_source = _resolve_value(
+        explicit_value=cookie,
+        env_names=(f"BIOOS_{normalized_service.upper()}_COOKIE", "BIOOS_AAI_COOKIE", "MIRACLE_AAI_COOKIE"),
+        config_values=(service_config.get("cookie"), service_config.get("session_cookie")),
+    )
+    resolved_url, url_source = _resolve_value(
+        explicit_value=None,
+        env_names=(f"BIOOS_{normalized_service.upper()}_URL",),
+        config_values=(service_config.get("url"),),
+        default=_default_aai_url(normalized_service),
+    )
+    return {
+        "service": normalized_service,
+        "token": resolved_token,
+        "token_source": token_source,
+        "cookie": resolved_cookie,
+        "cookie_source": cookie_source,
+        "url": resolved_url,
+        "url_source": url_source,
+        "passport_issued_at": service_config.get("passport_issued_at"),
+        "passport_expires_at": service_config.get("passport_expires_at"),
+        "passport_status": _derive_passport_status(
+            token=resolved_token,
+            expires_at=service_config.get("passport_expires_at"),
+        ),
+        "configured": bool(resolved_url),
+        "config_path": str(get_config_path()),
+    }
+
+
+def resolve_account_link_settings(path: Optional[str] = None) -> Dict[str, Optional[str]]:
+    account = load_account_config(path)
+    bioos_settings = resolve_auth_settings()
+    repo_aai = resolve_aai_settings(service="repo")
+    datasite_aai = resolve_aai_settings(service="datasite")
+    link_mode = account.get("link_mode")
+    return {
+        "link_mode": link_mode,
+        "status": _derive_account_link_status(
+            link_mode=link_mode,
+            bioos_access_key=bioos_settings.get("access_key"),
+            repo_token=repo_aai.get("token"),
+            datasite_token=datasite_aai.get("token"),
+        ),
+        "bioos_configured": bool(bioos_settings.get("access_key") and bioos_settings.get("secret_key")),
+        "aai_repo_configured": bool(repo_aai.get("token") or repo_aai.get("cookie")),
+        "aai_datasite_configured": bool(datasite_aai.get("token") or datasite_aai.get("cookie")),
+        "config_path": str(get_config_path(path)),
+    }
+
+
+def resolve_main_web_settings(
+    login_token: Optional[str] = None,
+    csrf_token: Optional[str] = None,
+    cookie: Optional[str] = None,
+    url: Optional[str] = None,
+) -> Dict[str, Optional[str]]:
+    web = load_main_web_config()
+    resolved_login_token, login_token_source = _resolve_value(
+        explicit_value=login_token,
+        env_names=("BIOOS_MAIN_LOGIN_TOKEN",),
+        config_values=(web.get("login_token"), web.get("x_login_token")),
+    )
+    resolved_csrf_token, csrf_token_source = _resolve_value(
+        explicit_value=csrf_token,
+        env_names=("BIOOS_MAIN_CSRF_TOKEN",),
+        config_values=(web.get("csrf_token"),),
+    )
+    resolved_cookie, cookie_source = _resolve_value(
+        explicit_value=cookie,
+        env_names=("BIOOS_MAIN_COOKIE",),
+        config_values=(web.get("cookie"),),
+    )
+    resolved_url, url_source = _resolve_value(
+        explicit_value=url,
+        env_names=("BIOOS_MAIN_WEB_URL",),
+        config_values=(web.get("url"),),
+        default="https://cloud.miracle.ac.cn",
+    )
+    return {
+        "url": resolved_url,
+        "url_source": url_source,
+        "login_token": resolved_login_token,
+        "login_token_source": login_token_source,
+        "csrf_token": resolved_csrf_token,
+        "csrf_token_source": csrf_token_source,
+        "cookie": resolved_cookie,
+        "cookie_source": cookie_source,
         "config_path": str(get_config_path()),
     }
 
@@ -92,6 +203,112 @@ def login_with_args(args: Any) -> Tuple[str, str, str]:
     )
 
 
+def resolve_aai_with_args(args: Any, service: str = "repo") -> Dict[str, Optional[str]]:
+    return resolve_aai_settings(
+        token=getattr(args, "token", None),
+        cookie=getattr(args, "cookie", None),
+        service=service,
+    )
+
+
+def build_repository_client(token: Optional[str] = None, cookie: Optional[str] = None) -> RepositoryClient:
+    settings = resolve_aai_settings(token=token, cookie=cookie, service="repo")
+    _ensure_aai_token_is_usable(settings, explicit_token=token)
+    return RepositoryClient(
+        base_url=settings["url"] or _default_aai_url("repo"),
+        token=settings["token"],
+        cookie=settings["cookie"],
+    )
+
+
+def build_datasite_client(token: Optional[str] = None, cookie: Optional[str] = None) -> DataSiteClient:
+    settings = resolve_aai_settings(token=token, cookie=cookie, service="datasite")
+    _ensure_aai_token_is_usable(settings, explicit_token=token)
+    return DataSiteClient(
+        base_url=settings["url"] or _default_aai_url("datasite"),
+        token=settings["token"],
+        cookie=settings["cookie"],
+    )
+
+
+def build_main_web_client(
+    login_token: Optional[str] = None,
+    csrf_token: Optional[str] = None,
+    cookie: Optional[str] = None,
+    url: Optional[str] = None,
+) -> MainWebClient:
+    settings = resolve_main_web_settings(
+        login_token=login_token,
+        csrf_token=csrf_token,
+        cookie=cookie,
+        url=url,
+    )
+    return MainWebClient(
+        base_url=settings["url"] or "https://cloud.miracle.ac.cn",
+        login_token=settings["login_token"],
+        csrf_token=settings["csrf_token"],
+        cookie=settings["cookie"],
+    )
+
+
+def login_to_main_web(
+    *,
+    account_name: str,
+    password: str,
+    user_name: Optional[str] = None,
+    url: Optional[str] = None,
+    timeout: int = 30,
+) -> Dict[str, Optional[str]]:
+    settings = resolve_main_web_settings(url=url)
+    return MainWebClient.login_with_password(
+        base_url=settings["url"] or "https://cloud.miracle.ac.cn",
+        account_name=account_name,
+        password=password,
+        user_name=user_name,
+        timeout=timeout,
+    )
+
+
+def _ensure_aai_token_is_usable(settings: Dict[str, Optional[str]], explicit_token: Optional[str] = None) -> None:
+    if explicit_token:
+        return
+    token = settings.get("token")
+    if not token:
+        return
+    passport_status = settings.get("passport_status")
+    if passport_status != "expired":
+        return
+    service = settings.get("service") or "repo"
+    expires_at = settings.get("passport_expires_at") or "unknown time"
+    raise ValueError(
+        f"{service} passport in {settings['config_path']} expired at {expires_at}. "
+        f"Run 'bioos aai refresh' or 'bioos aai login' to refresh it."
+    )
+
+
+def _derive_passport_status(token: Optional[str], expires_at: Optional[str]) -> str:
+    if not token:
+        return "missing"
+    if not expires_at:
+        return "unknown"
+    try:
+        expires_dt = _parse_iso8601(expires_at)
+    except ValueError:
+        return "unknown"
+    now = datetime.now(timezone.utc)
+    return "expired" if expires_dt <= now else "valid"
+
+
+def _parse_iso8601(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def resolve_workspace(workspace_name: str) -> Tuple[str, Dict[str, Any]]:
     from bioos import bioos
 
@@ -133,3 +350,33 @@ def _resolve_value(
         return default, "default"
 
     return None, "missing"
+
+
+def _default_aai_url(service: str) -> str:
+    normalized_service = _normalize_aai_service(service)
+    if normalized_service == "repo":
+        return "https://network.miracle.ac.cn"
+    return "https://mclibrary.miracle.ac.cn"
+
+
+def _normalize_aai_service(service: str) -> str:
+    normalized = (service or "repo").strip().lower()
+    if normalized not in {"repo", "datasite"}:
+        raise ValueError(f"Unsupported AAI service: {service}. Expected one of: repo, datasite.")
+    return normalized
+
+
+def _derive_account_link_status(
+    *,
+    link_mode: Optional[str],
+    bioos_access_key: Optional[str],
+    repo_token: Optional[str],
+    datasite_token: Optional[str],
+) -> str:
+    if not link_mode:
+        return "missing"
+    if bioos_access_key and (repo_token or datasite_token):
+        return "linked-ready"
+    if bioos_access_key or repo_token or datasite_token:
+        return "partially-configured"
+    return "configured"

--- a/bioos/service/datasite.py
+++ b/bioos/service/datasite.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from bioos.service.rest_base import RestClient
+
+
+class DataSiteClient(RestClient):
+    def list_applications(self, *, page: Optional[int] = None, size: Optional[int] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        return self.request("GET", "/api/data-library/application", params=params)
+
+    def permit_application(self, application_id: str, task_id: str) -> Any:
+        return self.request("PATCH", f"/api/data-library/application/{application_id}/permit/{task_id}")
+
+    def reject_application(self, application_id: str, task_id: str) -> Any:
+        return self.request("PATCH", f"/api/data-library/application/{application_id}/reject/{task_id}")
+
+    def list_datasets(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        tab: Optional[str] = None,
+        display_level: Optional[str] = None,
+        order_by: Optional[str] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if tab:
+            params["tab"] = tab
+        if display_level:
+            params["displayLevel"] = display_level
+        if order_by:
+            params["orderBy"] = order_by
+        return self.request("GET", "/api/data-library/data_set", params=params)
+
+    def get_dataset(self, data_set_id: str) -> Any:
+        return self.request("GET", "/api/data-library/data_set", params={"id": data_set_id})
+
+    def create_dataset(self, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", "/api/data-library/data_set", json_body=payload)
+
+    def apply_dataset(self, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", "/api/data-library/data_set/apply", json_body=payload)
+
+    def update_dataset(self, data_set_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("PUT", f"/api/data-library/data_set/{data_set_id}", json_body=payload)
+
+    def update_dataset_config(self, data_set_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("PATCH", f"/api/data-library/data_set/{data_set_id}/config", json_body=payload)
+
+    def delete_dataset(self, data_set_id: str) -> Any:
+        return self.request("DELETE", f"/api/data-library/data_set/{data_set_id}")
+
+    def get_dataset_permission(self, data_set_id: str) -> Any:
+        return self.request("GET", f"/api/data-library/data_set/{data_set_id}/permission")
+
+    def release_dataset(self, data_set_id: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("PUT", f"/api/data-library/data_set/{data_set_id}/release", json_body=payload or {})
+
+    def revoke_dataset(self, data_set_id: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("PUT", f"/api/data-library/data_set/{data_set_id}/revoke", json_body=payload or {})
+
+    def get_dataset_archive_access(self, *, path: Optional[str] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if path:
+            params["path"] = path
+        return self.request("GET", "/api/data-library/data_set/archive/tos_access", params=params)
+
+    def check_dataset(self, **params: Any) -> Any:
+        filtered = {key: value for key, value in params.items() if value is not None}
+        return self.request("GET", "/api/data-library/data_set/check", params=filtered)
+
+    def export_dataset(self, data_set_id: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("POST", f"/api/data-library/data_set/{data_set_id}/export", json_body=payload or {})
+
+    def import_dataset(self, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", "/api/data-library/data_set/import", json_body=payload)
+
+    def list_dataset_files(self, data_set_id: str, *, page: Optional[int] = None, size: Optional[int] = None, order_by: Optional[str] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if order_by:
+            params["orderBy"] = order_by
+        return self.request("GET", f"/api/data-library/data_set/{data_set_id}/data_file", params=params)
+
+    def upsert_dataset_files(self, data_set_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("PUT", f"/api/data-library/data_set/{data_set_id}/data_file", json_body=payload)
+
+    def delete_dataset_files(self, data_set_id: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("DELETE", f"/api/data-library/data_set/{data_set_id}/data_file", json_body=payload or {})
+
+    def list_dataset_file_ids(self, data_set_id: str) -> Any:
+        return self.request("GET", f"/api/data-library/data_set/{data_set_id}/data_file/ids")
+
+    def list_files(self, *, page: Optional[int] = None, size: Optional[int] = None, order_by: Optional[str] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if order_by:
+            params["orderBy"] = order_by
+        return self.request("GET", "/api/data-library/data_file", params=params)
+
+    def list_file_types(self) -> Any:
+        return self.request("GET", "/api/data-library/data_file/types")
+
+    def list_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+        job_type: Optional[str] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if order_by:
+            params["orderBy"] = order_by
+        if scope:
+            params["scope"] = scope
+        if job_type:
+            params["type"] = job_type
+        return self.request("GET", "/api/data-library/schema_job", params=params)
+
+    def delete_schema_job(self, job_id: str) -> Any:
+        return self.request("DELETE", f"/api/data-library/schema_job/{job_id}")
+
+    def get_export_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+    ) -> Any:
+        return self.list_schema_jobs(page=page, size=size, order_by=order_by, scope=scope, job_type="export")
+
+    def get_import_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+    ) -> Any:
+        return self.list_schema_jobs(page=page, size=size, order_by=order_by, scope=scope, job_type="import")
+
+    def get_drs_object(self, object_id: str) -> Any:
+        return self.request("GET", f"/ga4gh/drs/v1/objects/{object_id}")
+
+    def post_drs_object(self, object_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", f"/ga4gh/drs/v1/objects/{object_id}", json_body=payload)
+
+    def get_drs_access(self, object_id: str, access_id: str) -> Any:
+        return self.request("GET", f"/ga4gh/drs/v1/objects/{object_id}/access/{access_id}")
+
+    def post_drs_access(self, object_id: str, access_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", f"/ga4gh/drs/v1/objects/{object_id}/access/{access_id}", json_body=payload)

--- a/bioos/service/main_web.py
+++ b/bioos/service/main_web.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+from bioos.service.rest_base import RestClient
+
+LOGIN_AES_KEY = b"0102030405060708"
+DEFAULT_LOGIN_REFERER = "/product/mc"
+
+
+def encrypt_main_web_password(password: str) -> str:
+    plaintext = password.encode("utf-8")
+    pad_size = 16 - (len(plaintext) % 16)
+    padded = plaintext + bytes([pad_size]) * pad_size
+
+    try:
+        from Crypto.Cipher import AES  # type: ignore
+
+        cipher = AES.new(LOGIN_AES_KEY, AES.MODE_ECB)
+        ciphertext = cipher.encrypt(padded)
+        return base64.b64encode(ciphertext).decode("utf-8")
+    except Exception:
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        cipher = Cipher(algorithms.AES(LOGIN_AES_KEY), modes.ECB(), backend=default_backend())
+        encryptor = cipher.encryptor()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+        return base64.b64encode(ciphertext).decode("utf-8")
+
+
+class MainWebLoginSession:
+    def __init__(self, base_url: str, timeout: int = 30) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.cookie_jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self.cookie_jar))
+
+    def initialize(self) -> dict:
+        request = urllib.request.Request(
+            f"{self.base_url}/login?redirect_uri=%2F",
+            headers={"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+        )
+        with self.opener.open(request, timeout=self.timeout):
+            pass
+        return self.export_auth()
+
+    def login(
+        self,
+        *,
+        account_name: str,
+        password: str,
+        user_name: Optional[str] = None,
+        platform: str = "tenant",
+        language: str = "zh",
+    ) -> dict:
+        auth = self.initialize()
+        csrf_token = auth.get("csrf_token")
+        payload: Dict[str, Any] = {
+            "Platform": platform,
+            "UserType": "user" if user_name else "account",
+            "AccountName": account_name,
+            "Pass": encrypt_main_web_password(password),
+        }
+        if user_name:
+            payload["UserName"] = user_name
+
+        request = urllib.request.Request(
+            f"{self.base_url}/api/auth/login",
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            method="POST",
+            headers={
+                "Accept": "application/json, text/plain, */*",
+                "Content-Type": "application/json",
+                "Referer": DEFAULT_LOGIN_REFERER,
+                "x-language": language,
+                **({"x-csrf-token": csrf_token} if csrf_token else {}),
+            },
+        )
+        try:
+            with self.opener.open(request, timeout=self.timeout) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Main web login failed: HTTP {exc.code}: {body}") from exc
+
+        result = json.loads(body) if body else {}
+        exported = self.export_auth()
+        exported["login_result"] = result
+        exported["login_token"] = result.get("LoginToken")
+        return exported
+
+    def export_auth(self) -> dict:
+        cookies = []
+        csrf_token = None
+        for cookie in self.cookie_jar:
+            cookies.append(f"{cookie.name}={cookie.value}")
+            if cookie.name == "csrfToken":
+                csrf_token = cookie.value
+        return {
+            "web_url": self.base_url,
+            "csrf_token": csrf_token,
+            "cookie": "; ".join(cookies) or None,
+        }
+
+
+class MainWebClient(RestClient):
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        login_token: Optional[str] = None,
+        csrf_token: Optional[str] = None,
+        cookie: Optional[str] = None,
+        timeout: int = 30,
+    ) -> None:
+        headers: Dict[str, str] = {"X-TOP-REGION": "cn-north-1"}
+        if login_token:
+            headers["X-LoginToken"] = login_token
+        if csrf_token:
+            headers["x-csrf-token"] = csrf_token
+        super().__init__(base_url=base_url, cookie=cookie, timeout=timeout)
+        self.default_headers = headers
+
+    @classmethod
+    def login_with_password(
+        cls,
+        *,
+        base_url: str,
+        account_name: str,
+        password: str,
+        user_name: Optional[str] = None,
+        timeout: int = 30,
+    ) -> dict:
+        session = MainWebLoginSession(base_url=base_url, timeout=timeout)
+        return session.login(account_name=account_name, password=password, user_name=user_name)
+
+    def graphql(self, operation_name: str, query: str, variables: Optional[Dict[str, Any]] = None) -> Any:
+        payload = {
+            "operationName": operation_name,
+            "query": query,
+            "variables": variables or {},
+        }
+        return self.request(
+            "POST",
+            f"/api/product/bio-pipeline/graphql?{operation_name}",
+            json_body=payload,
+            headers=self.default_headers,
+        )
+
+    def check_repository_account_exist(self) -> Any:
+        query = """
+query CheckRepositoryAccountExist($body: CheckRepositoryAccountExistRequestInput) {
+  CheckRepositoryAccountExist(body: $body) {
+    Exist
+    Email
+    Organizations {
+      ID
+      Name
+      Owner
+      Phone
+    }
+  }
+}
+""".strip()
+        result = self.graphql(
+            "CheckRepositoryAccountExist",
+            query,
+            {"body": {}},
+        )
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, dict):
+                return data.get("CheckRepositoryAccountExist", data)
+        return result
+
+    def get_repository_passport(self, *, expires_in: Optional[int] = None) -> Any:
+        query = """
+query GetRepositoryPassport($body: NetworkGetRepositoryPassportRequestInput) {
+  GetRepositoryPassport(body: $body) {
+    Passport
+  }
+}
+""".strip()
+        body: Dict[str, Any] = {}
+        if expires_in is not None:
+            body["ExpiresIn"] = expires_in
+        result = self.graphql(
+            "GetRepositoryPassport",
+            query,
+            {"body": body},
+        )
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, dict):
+                return data.get("GetRepositoryPassport", data)
+        return result

--- a/bioos/service/repository.py
+++ b/bioos/service/repository.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from bioos.service.rest_base import RestClient
+
+
+class RepositoryClient(RestClient):
+    def list_datasets(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        display_level: Optional[str] = None,
+        order_by: Optional[str] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if display_level:
+            params["displayLevel"] = display_level
+        if order_by:
+            params["orderBy"] = order_by
+        return self.request("GET", "/api/repository/data_set", params=params)
+
+    def get_dataset(self, data_set_id: str) -> Any:
+        return self.request("GET", "/api/repository/data_set", params={"id": data_set_id})
+
+    def export_dataset(self, data_set_id: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        return self.request("POST", f"/api/repository/data_set/{data_set_id}/export", json_body=payload or {})
+
+    def import_dataset(self, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", "/api/repository/data_set/import", json_body=payload)
+
+    def get_dataset_archive_access(self, *, path: Optional[str] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if path:
+            params["path"] = path
+        return self.request("GET", "/api/repository/data_set/archive/tos_access", params=params)
+
+    def list_dataset_files(
+        self,
+        data_set_id: str,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if order_by:
+            params["orderBy"] = order_by
+        return self.request("GET", f"/api/repository/data_set/{data_set_id}/data_file", params=params)
+
+    def list_dataset_file_ids(self, data_set_id: str) -> Any:
+        return self.request("GET", f"/api/repository/data_set/{data_set_id}/data_file/ids")
+
+    def list_dacs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        limit: Optional[int] = None,
+        scope: Optional[list[str]] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if limit is not None:
+            params["limit"] = limit
+        if scope:
+            params["scope"] = scope
+        return self.request("GET", "/api/repository/dac", params=params)
+
+    def list_applications(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        app_type: Optional[str] = None,
+        field: Optional[str] = None,
+        show_pending_approval: Optional[bool] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if app_type:
+            params["type"] = app_type
+        if field:
+            params["field"] = field
+        if show_pending_approval is not None:
+            params["showPendingApproval"] = str(show_pending_approval).lower()
+        return self.request("GET", "/api/repository/application", params=params)
+
+    def list_admins(self) -> Any:
+        return self.request("GET", "/pylons/api/v1/admins")
+
+    def get_organization_names(self, organization_id: str) -> Any:
+        return self.request("GET", "/pylons/api/v1/organizationNames", params={"id": organization_id})
+
+    def get_identity(self, identity_id: str) -> Any:
+        return self.request("GET", "/pylons/api/v1/identities", params={"id": identity_id})
+
+    def list_libraries(self) -> Any:
+        return self.request("GET", "/api/repository/data_library")
+
+    def list_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+        job_type: Optional[str] = None,
+    ) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if order_by:
+            params["orderBy"] = order_by
+        if scope:
+            params["scope"] = scope
+        if job_type:
+            params["type"] = job_type
+        return self.request("GET", "/api/repository/schema_job", params=params)
+
+    def get_export_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+    ) -> Any:
+        return self.list_schema_jobs(page=page, size=size, order_by=order_by, scope=scope, job_type="export")
+
+    def get_import_schema_jobs(
+        self,
+        *,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        scope: Optional[list[str]] = None,
+    ) -> Any:
+        return self.list_schema_jobs(page=page, size=size, order_by=order_by, scope=scope, job_type="import")
+
+    def get_datasite_pre_signed_url(self, filename: str) -> Any:
+        return self.request("GET", "/api/repository/data_site/pre_signed_url", params={"filename": filename})
+
+    def create_dac(self, payload: Dict[str, Any]) -> Any:
+        return self.request("POST", "/api/repository/dac", json_body=payload)
+
+    def update_dac(self, dac_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("PUT", f"/api/repository/dac/{dac_id}", json_body=payload)
+
+    def delete_dac(self, dac_id: str) -> Any:
+        return self.request("DELETE", f"/api/repository/dac/{dac_id}")
+
+    def check_dac(self, *, name: Optional[str] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if name:
+            params["name"] = name
+        return self.request("GET", "/api/repository/dac/check", params=params)
+
+    def list_dac_members(self, dac_id: str, *, page: Optional[int] = None, size: Optional[int] = None) -> Any:
+        params: Dict[str, Any] = {}
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        return self.request("GET", f"/api/repository/dac/{dac_id}/member", params=params)
+
+    def upsert_dac_member(self, dac_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("PUT", f"/api/repository/dac/{dac_id}/member", json_body=payload)
+
+    def remove_dac_member(self, dac_id: str, payload: Dict[str, Any]) -> Any:
+        return self.request("DELETE", f"/api/repository/dac/{dac_id}/member", json_body=payload)

--- a/bioos/service/rest_base.py
+++ b/bioos/service/rest_base.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Dict, Optional
+from urllib import parse
+
+
+class RestClient:
+    def __init__(self, base_url: str, token: Optional[str] = None, cookie: Optional[str] = None, timeout: int = 30):
+        if not base_url:
+            raise ValueError("Missing base URL.")
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.cookie = cookie
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        if params:
+            query = parse.urlencode({key: value for key, value in params.items() if value is not None}, doseq=True)
+            if query:
+                url = f"{url}?{query}"
+
+        cmd = [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--write-out",
+            "\n__BIOOS_STATUS__:%{http_code}\n__BIOOS_CONTENT_TYPE__:%{content_type}",
+            "--max-time",
+            str(self.timeout),
+            "-X",
+            method.upper(),
+            "-H",
+            "Accept: application/json, text/plain, */*",
+        ]
+        if self.token:
+            cmd.extend(["-H", f"Authorization: Bearer {self.token}"])
+        if self.cookie:
+            cmd.extend(["-H", f"Cookie: {self.cookie}"])
+        if headers:
+            for key, value in headers.items():
+                cmd.extend(["-H", f"{key}: {value}"])
+        if json_body is not None:
+            cmd.extend(["-H", "Content-Type: application/json", "--data", json.dumps(json_body, ensure_ascii=False)])
+        cmd.append(url)
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"Request failed for {method.upper()} {url}: {result.stderr.strip() or result.stdout.strip()}")
+
+        raw_output = result.stdout
+        status_marker = "\n__BIOOS_STATUS__:"
+        content_type_marker = "\n__BIOOS_CONTENT_TYPE__:"
+        status_pos = raw_output.rfind(status_marker)
+        content_type_pos = raw_output.rfind(content_type_marker)
+        if status_pos == -1 or content_type_pos == -1 or content_type_pos < status_pos:
+            raise RuntimeError(f"Unexpected curl output for {method.upper()} {url}.")
+
+        body = raw_output[:status_pos]
+        status_code = raw_output[status_pos + len(status_marker):content_type_pos].strip()
+        content_type = raw_output[content_type_pos + len(content_type_marker):].strip()
+        try:
+            status = int(status_code)
+        except ValueError as exc:
+            raise RuntimeError(f"Invalid HTTP status for {method.upper()} {url}: {status_code}") from exc
+
+        if status >= 400:
+            raise RuntimeError(f"HTTP {status} for {method.upper()} {url}: {body.strip()}")
+
+        if "application/json" in content_type:
+            return json.loads(body) if body else {}
+        return body

--- a/examples/datasite/apply-dataset.json
+++ b/examples/datasite/apply-dataset.json
@@ -1,0 +1,6 @@
+{
+  "type": "DataSetCreate",
+  "dataSetID": "replace-with-created-data-set-id",
+  "title": "Publish mc-dataset-demo to data site",
+  "reason": "Initial release from pybioos workflow."
+}

--- a/examples/datasite/create-dataset.json
+++ b/examples/datasite/create-dataset.json
@@ -1,0 +1,40 @@
+{
+  "name": "mc-dataset-demo",
+  "description": "Demo data set created from pybioos CLI.",
+  "createTime": 1778112000,
+  "updateTime": 1778112000,
+  "owners": "BioOS Team",
+  "category": "Genomics",
+  "catalogue": "Human omics",
+  "labels": [
+    "WGS",
+    "Cancer"
+  ],
+  "docURL": "https://example.org/docs/mc-dataset-demo",
+  "emails": [
+    "owner@example.org"
+  ],
+  "licence": "CC-BY-4.0",
+  "projectDataTypes": [
+    "FASTQ",
+    "BAM"
+  ],
+  "sampleScope": "Human cohort",
+  "externalLink": "https://example.org/project/mc-dataset-demo",
+  "externalLinkDescription": "Project home page",
+  "exampleTutorial": "https://example.org/tutorials/mc-dataset-demo",
+  "tools": "https://example.org/tools/mc-dataset-demo",
+  "publications": [
+    {
+      "name": "Example publication",
+      "accessURL": "https://doi.org/10.1000/example",
+      "authors": "Alice Zhang; Bob Li",
+      "quotation": "Zhang A, Li B. Example dataset paper. 2025."
+    }
+  ],
+  "dataFilesAccessURL": "https://example.org/downloads/mc-dataset-demo/files.csv",
+  "dataSetAccessMethodURL": "https://example.org/downloads/mc-dataset-demo/access_methods.json",
+  "dataSetTablesAccessURL": {
+    "sample_sheet": "https://example.org/downloads/mc-dataset-demo/sample_sheet.tsv"
+  }
+}

--- a/examples/datasite/data-files-template.csv
+++ b/examples/datasite/data-files-template.csv
@@ -1,0 +1,3 @@
+File name,File description,Date created,Last updated,File type,File size,Data source,Data path
+example_01.fastq.gz,Paired-end read 1,24-05-01,24-05-01,FASTQ,123456789,submitted by sequencing center,s3://bucket/path/example_01.fastq.gz
+example_02.cram,Aligned reads,24-05-01,24-05-02,CRAM,234567890,repository mirror,s3://bucket/path/example_02.cram

--- a/examples/datasite/delete-files.json
+++ b/examples/datasite/delete-files.json
@@ -1,0 +1,6 @@
+{
+  "dataFileIDs": [
+    "replace-with-file-id-1",
+    "replace-with-file-id-2"
+  ]
+}

--- a/examples/datasite/release-dataset.json
+++ b/examples/datasite/release-dataset.json
@@ -1,0 +1,3 @@
+{
+  "comment": "Release approved and ready for publication."
+}

--- a/examples/datasite/update-config.json
+++ b/examples/datasite/update-config.json
@@ -1,0 +1,7 @@
+{
+  "customHeaderOrders": {
+    "sample_id": "1",
+    "subject_id": "2",
+    "tumor_type": "3"
+  }
+}

--- a/examples/datasite/upsert-files.json
+++ b/examples/datasite/upsert-files.json
@@ -1,0 +1,21 @@
+{
+  "dataFiles": [
+    {
+      "name": "example_01.fastq.gz",
+      "description": "Paired-end read 1",
+      "createTime": 1778112000,
+      "updateTime": 1778112000,
+      "fileType": "FASTQ",
+      "fileSize": 123456789,
+      "accessURL": "s3://bucket/path/example_01.fastq.gz",
+      "source": "s3://bucket/path/example_01.fastq.gz",
+      "checksums": [
+        {
+          "type": "md5",
+          "value": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ]
+    }
+  ],
+  "duplicatedReplace": true
+}

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -37,9 +38,623 @@ from bioos.cli import (
 )
 from bioos import bioos_workflow, bw_import, bw_import_status_check, bw_status_check, get_submission_logs as submission_logs_module
 from bioos.ops import auth as auth_ops
+from bioos.service.main_web import encrypt_main_web_password
 
 
 class TestCliHandlers(unittest.TestCase):
+    def test_handle_aai_import_main_web_curl(self):
+        args = SimpleNamespace(
+            curl=(
+                "curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' "
+                "-H 'x-csrf-token: csrf-123456' "
+                "-H 'x-logintoken: login-token-abcdef' "
+                "-b 'tenant=abc; csrfToken=csrf-123456'"
+            ),
+            curl_file=None,
+        )
+        result = cli_main._handle_aai_import_main_web_curl(args)
+        self.assertEqual(result["web_url"], "https://cloud.miracle.ac.cn")
+        self.assertEqual(result["login_token"], "login-token-abcdef")
+        self.assertEqual(result["csrf_token"], "csrf-123456")
+        self.assertTrue(result["cookie_configured"])
+
+    def test_handle_aai_status(self):
+        args = SimpleNamespace(
+            web_url="https://cloud.miracle.ac.cn",
+            login_token="login-token",
+            csrf_token="csrf-token",
+            cookie="tenant=abc; csrfToken=csrf-token",
+        )
+        with patch("bioos.ops.auth.resolve_main_web_settings", return_value={
+            "url": "https://cloud.miracle.ac.cn",
+            "url_source": "cli",
+            "login_token_source": "cli",
+            "login_token": "login-token",
+            "csrf_token_source": "cli",
+            "csrf_token": "csrf-token",
+            "cookie_source": "cli",
+            "cookie": "tenant=abc",
+        }), \
+                patch("bioos.ops.auth.resolve_aai_settings", side_effect=[
+                    {
+                        "url": "https://network.miracle.ac.cn",
+                        "url_source": "config",
+                        "token_source": "config",
+                        "token": "repo-token",
+                        "cookie_source": "missing",
+                        "cookie": None,
+                        "passport_issued_at": "2026-05-07T00:00:00+00:00",
+                        "passport_expires_at": "2026-06-06T00:00:00+00:00",
+                        "passport_status": "valid",
+                    },
+                    {
+                        "url": "https://mclibrary.miracle.ac.cn",
+                        "url_source": "config",
+                        "token_source": "config",
+                        "token": "datasite-token",
+                        "cookie_source": "missing",
+                        "cookie": None,
+                        "passport_issued_at": "2026-05-07T00:00:00+00:00",
+                        "passport_expires_at": "2026-06-06T00:00:00+00:00",
+                        "passport_status": "valid",
+                    },
+                ]):
+            result = cli_main._handle_aai_status(args)
+        self.assertTrue(result["main_web"]["login_token_configured"])
+        self.assertTrue(result["repo"]["token_configured"])
+        self.assertTrue(result["datasite"]["token_configured"])
+        self.assertEqual(result["repo"]["passport_status"], "valid")
+
+    def test_handle_aai_sync_from_bioos_saves_repo_and_datasite(self):
+        args = SimpleNamespace(
+            web_url="https://cloud.miracle.ac.cn",
+            login_token="login-token",
+            csrf_token="csrf-token",
+            cookie="tenant=abc; csrfToken=csrf-token",
+            expires_in=3600,
+            config_path="/tmp/test-config.yaml",
+        )
+        fake_client = MagicMock()
+        fake_client.get_repository_passport.return_value = {"Passport": "passport-token"}
+        with patch("bioos.ops.auth.resolve_main_web_settings", return_value={
+            "url": "https://cloud.miracle.ac.cn",
+            "url_source": "cli",
+            "login_token_source": "cli",
+            "csrf_token_source": "cli",
+            "cookie_source": "cli",
+        }), \
+                patch("bioos.ops.auth.build_main_web_client", return_value=fake_client), \
+                patch("bioos.cli.config_store.update_section_values", side_effect=[
+                    Path("/tmp/test-config.yaml"),
+                    Path("/tmp/test-config.yaml"),
+                ]) as update_mock:
+            result = cli_main._handle_aai_sync_from_bioos(args)
+        self.assertTrue(result["synced"])
+        self.assertEqual(len(result["saved"]), 2)
+        self.assertEqual(update_mock.call_count, 2)
+        self.assertIsNotNone(result["passport_expires_at"])
+
+    def test_datasite_download_files_parser_accepts_filters(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "datasite",
+                "dataset",
+                "download-files",
+                "--data-set-id",
+                "ds1",
+                "--target",
+                "./downloads",
+                "--name-contains",
+                "tumor",
+                "--limit",
+                "2",
+                "--dry-run",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_datasite_dataset_download_files)
+        self.assertEqual(args.data_set_id, "ds1")
+        self.assertTrue(args.dry_run)
+
+    def test_handle_datasite_dataset_download_files_dry_run(self):
+        args = SimpleNamespace(
+            token=None,
+            cookie=None,
+            data_set_id="ds1",
+            target="./downloads",
+            page=1,
+            size=100,
+            order_by="id:asc",
+            name_contains="tumor",
+            regex=None,
+            drs_url=None,
+            limit=1,
+            dry_run=True,
+        )
+        fake_client = MagicMock()
+        fake_client.list_dataset_files.return_value = {
+            "items": [
+                {"id": "f1", "name": "tumor.fastq.gz", "drsURL": "drs://imc-drs.miracle.ac.cn/obj1"},
+                {"id": "f2", "name": "normal.fastq.gz", "drsURL": "drs://imc-drs.miracle.ac.cn/obj2"},
+            ]
+        }
+        with patch("bioos.ops.auth.build_datasite_client", return_value=fake_client), \
+                patch("urllib.request.urlretrieve") as download_mock:
+            result = cli_main._handle_datasite_dataset_download_files(args)
+        self.assertEqual(result["matched_count"], 1)
+        self.assertEqual(result["downloaded_count"], 0)
+        self.assertTrue(result["dry_run"])
+        download_mock.assert_not_called()
+
+    def test_handle_datasite_dataset_download_files_downloads_matches(self):
+        args = SimpleNamespace(
+            token=None,
+            cookie=None,
+            data_set_id="ds1",
+            target="./downloads",
+            page=1,
+            size=100,
+            order_by="id:asc",
+            name_contains=None,
+            regex="tumor",
+            drs_url=None,
+            limit=None,
+            dry_run=False,
+        )
+        fake_client = MagicMock()
+        fake_client.list_dataset_files.return_value = {
+            "items": [
+                {"id": "f1", "name": "tumor.fastq.gz", "drsURL": "drs://imc-drs.miracle.ac.cn/obj1"},
+                {"id": "f2", "name": "normal.fastq.gz", "drsURL": "drs://imc-drs.miracle.ac.cn/obj2"},
+            ]
+        }
+        with patch("bioos.ops.auth.build_datasite_client", return_value=fake_client), \
+                patch("bioos.cli.main._resolve_drs_download_info", return_value={
+                    "object_id": "obj1",
+                    "access_url": "https://example.org/tumor.fastq.gz",
+                    "file_name": "tumor.fastq.gz",
+                }), \
+                patch("urllib.request.urlretrieve") as download_mock:
+            result = cli_main._handle_datasite_dataset_download_files(args)
+        self.assertEqual(result["matched_count"], 1)
+        self.assertEqual(result["downloaded_count"], 1)
+        self.assertEqual(result["items"][0]["name"], "tumor.fastq.gz")
+        download_mock.assert_called_once()
+
+    def test_handle_aai_sync_from_curl_extracts_and_syncs(self):
+        args = SimpleNamespace(
+            curl=(
+                "curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' "
+                "-H 'x-csrf-token: csrf-123456' "
+                "-H 'x-logintoken: login-token-abcdef' "
+                "-b 'tenant=abc; csrfToken=csrf-123456'"
+            ),
+            curl_file=None,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.main._handle_aai_sync_from_bioos", return_value={
+            "synced": True,
+            "saved": [{"section": "repo"}, {"section": "datasite"}],
+        }) as sync_mock:
+            result = cli_main._handle_aai_sync_from_curl(args)
+        self.assertTrue(result["synced"])
+        self.assertTrue(result["extracted"]["cookie_configured"])
+        sync_args = sync_mock.call_args.args[0]
+        self.assertEqual(sync_args.web_url, "https://cloud.miracle.ac.cn")
+        self.assertEqual(sync_args.login_token, "login-token-abcdef")
+
+    def test_aai_login_parser_accepts_curl(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "aai",
+                "login",
+                "--curl",
+                "curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' -H 'x-csrf-token: csrf-123456' -H 'x-logintoken: login-token-abcdef' -b 'tenant=abc; csrfToken=csrf-123456'",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_aai_login)
+        self.assertTrue(args.save_main_web)
+        self.assertTrue(args.sync_passport)
+
+    def test_aai_login_parser_accepts_password_login(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "aai",
+                "login",
+                "--account-name",
+                "Pretest",
+                "--password",
+                "secret-password",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_aai_login)
+        self.assertEqual(args.account_name, "Pretest")
+        self.assertEqual(args.password, "secret-password")
+
+    def test_encrypt_main_web_password_matches_reference(self):
+        self.assertEqual(encrypt_main_web_password("123456"), "Gx7rhCBtpV5Nd+YpsVyFZQ==")
+
+    def test_handle_aai_login_with_password_login(self):
+        args = SimpleNamespace(
+            account_name="Pretest",
+            password="secret-password",
+            user_name=None,
+            web_url="https://cloud.miracle.ac.cn",
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl=None,
+            curl_file=None,
+            save_main_web=False,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.ops.auth.login_to_main_web", return_value={
+            "web_url": "https://cloud.miracle.ac.cn",
+            "login_token": "login-token-from-password",
+            "csrf_token": "csrf-token-from-password",
+            "cookie": "tenant=abc; csrfToken=csrf-token-from-password",
+            "login_result": {
+                "AccountName": "Pretest",
+                "Email": "pretest@example.com",
+                "Role": 1,
+            },
+        }), patch("bioos.cli.main._handle_aai_account_status", return_value={
+            "linked": True,
+            "result": {"Exist": True},
+        }), patch("bioos.cli.main._handle_aai_sync_from_bioos", return_value={
+            "synced": True,
+            "saved": [{"section": "repo"}, {"section": "datasite"}],
+            "passport_masked": "pass...rt",
+        }):
+            result = cli_main._handle_aai_login(args)
+        self.assertEqual(result["mode"], "password")
+        self.assertTrue(result["synced"])
+        self.assertTrue(result["main_web"]["login_token_configured"])
+        self.assertEqual(result["extracted"]["login_result"]["account_name"], "Pretest")
+
+    def test_handle_aai_login_saves_main_web_and_syncs(self):
+        args = SimpleNamespace(
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url="https://cloud.miracle.ac.cn",
+            login_token="login-token",
+            csrf_token="csrf-token",
+            cookie="tenant=abc; csrfToken=csrf-token",
+            curl=None,
+            curl_file=None,
+            save_main_web=True,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.config_store.update_section_values", return_value=Path("/tmp/test-config.yaml")) as update_mock, \
+                patch("bioos.cli.main._handle_aai_account_status", return_value={
+                    "linked": True,
+                    "result": {"Exist": True},
+                }), \
+                patch("bioos.cli.main._handle_aai_sync_from_bioos", return_value={
+                    "synced": True,
+                    "saved": [{"section": "repo"}, {"section": "datasite"}],
+                    "passport_masked": "pass...port",
+                }):
+            result = cli_main._handle_aai_login(args)
+        self.assertTrue(result["synced"])
+        self.assertEqual(result["mode"], "direct")
+        self.assertEqual(result["saved"][0]["section"], "main_web")
+        update_mock.assert_called_once()
+
+    def test_handle_aai_login_from_curl_without_sync(self):
+        args = SimpleNamespace(
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url=None,
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl=(
+                "curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' "
+                "-H 'x-csrf-token: csrf-123456' "
+                "-H 'x-logintoken: login-token-abcdef' "
+                "-b 'tenant=abc; csrfToken=csrf-123456'"
+            ),
+            curl_file=None,
+            save_main_web=False,
+            sync_passport=False,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        result = cli_main._handle_aai_login(args)
+        self.assertFalse(result["synced"])
+        self.assertEqual(result["mode"], "curl")
+        self.assertTrue(result["main_web"]["login_token_configured"])
+        self.assertIn("extracted", result)
+
+    def test_handle_aai_login_stops_before_passport_when_account_not_linked(self):
+        args = SimpleNamespace(
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url="https://cloud.miracle.ac.cn",
+            login_token="login-token",
+            csrf_token="csrf-token",
+            cookie="tenant=abc; csrfToken=csrf-token",
+            curl=None,
+            curl_file=None,
+            save_main_web=False,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.main._handle_aai_account_status", return_value={
+            "linked": False,
+            "result": {"Exist": False},
+        }), patch("bioos.cli.main._handle_aai_sync_from_bioos") as sync_mock:
+            result = cli_main._handle_aai_login(args)
+        self.assertFalse(result["synced"])
+        self.assertFalse(result["account_link"]["linked"])
+        self.assertIn("not linked", result["message"])
+        sync_mock.assert_not_called()
+
+    def test_handle_aai_login_rejects_mixed_direct_and_curl_auth(self):
+        args = SimpleNamespace(
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url="https://cloud.miracle.ac.cn",
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl="curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist'",
+            curl_file=None,
+            save_main_web=True,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with self.assertRaises(ValueError):
+            cli_main._handle_aai_login(args)
+
+    def test_auth_connect_aai_parser_accepts_bioos_and_curl_inputs(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "auth",
+                "connect-aai",
+                "--ak",
+                "ak-value",
+                "--sk",
+                "sk-value",
+                "--curl",
+                "curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' -H 'x-csrf-token: csrf-123456' -H 'x-logintoken: login-token-abcdef' -b 'tenant=abc; csrfToken=csrf-123456'",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_auth_connect_aai)
+        self.assertEqual(args.ak, "ak-value")
+        self.assertEqual(args.sk, "sk-value")
+        self.assertTrue(args.save_client)
+        self.assertTrue(args.save_main_web)
+        self.assertTrue(args.sync_passport)
+
+    def test_auth_connect_aai_parser_accepts_password_login(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "auth",
+                "connect-aai",
+                "--ak",
+                "ak-value",
+                "--sk",
+                "sk-value",
+                "--account-name",
+                "Pretest",
+                "--password",
+                "secret-password",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_auth_connect_aai)
+        self.assertEqual(args.account_name, "Pretest")
+        self.assertEqual(args.password, "secret-password")
+
+    def test_aai_refresh_parser_accepts_password_login(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "aai",
+                "refresh",
+                "--account-name",
+                "Pretest",
+                "--password",
+                "secret-password",
+            ]
+        )
+        self.assertIs(args.handler, cli_main._handle_aai_refresh)
+        self.assertEqual(args.account_name, "Pretest")
+
+    def test_handle_aai_refresh_marks_refreshed(self):
+        args = SimpleNamespace(
+            account_name="Pretest",
+            password="secret-password",
+            user_name=None,
+            web_url=None,
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl=None,
+            curl_file=None,
+            save_main_web=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.main._handle_aai_login", return_value={"synced": True, "saved": []}):
+            result = cli_main._handle_aai_refresh(args)
+        self.assertTrue(result["refreshed"])
+
+    def test_handle_auth_connect_aai_stops_when_bioos_auth_fails(self):
+        args = SimpleNamespace(
+            ak="ak-value",
+            sk="sk-value",
+            endpoint="https://bio-top.miracle.ac.cn",
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url=None,
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl=None,
+            curl_file=None,
+            save_client=True,
+            save_main_web=True,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.main.resolve_auth_settings", return_value={
+            "access_key": "ak-value",
+            "secret_key": "sk-value",
+            "endpoint": "https://bio-top.miracle.ac.cn",
+            "region": None,
+        }), \
+                patch("bioos.cli.config_store.update_section_values", return_value=Path("/tmp/test-config.yaml")) as update_mock, \
+                patch("bioos.cli.main._handle_auth_status", return_value={
+                    "success": False,
+                    "error": "bad credentials",
+                }), \
+                patch("bioos.cli.main._handle_aai_login") as aai_login_mock:
+            result = cli_main._handle_auth_connect_aai(args)
+        self.assertFalse(result["synced"])
+        self.assertEqual(result["saved"][0]["section"], "client")
+        update_mock.assert_called_once()
+        aai_login_mock.assert_not_called()
+
+    def test_handle_auth_connect_aai_runs_auth_then_aai_login(self):
+        args = SimpleNamespace(
+            ak="ak-value",
+            sk="sk-value",
+            endpoint="https://bio-top.miracle.ac.cn",
+            account_name=None,
+            password=None,
+            user_name=None,
+            web_url=None,
+            login_token=None,
+            csrf_token=None,
+            cookie=None,
+            curl="curl 'https://cloud.miracle.ac.cn/api/product/bio-pipeline/graphql?CheckRepositoryAccountExist' -H 'x-csrf-token: csrf-123456' -H 'x-logintoken: login-token-abcdef' -b 'tenant=abc; csrfToken=csrf-123456'",
+            curl_file=None,
+            save_client=True,
+            save_main_web=True,
+            sync_passport=True,
+            expires_in=2592000,
+            config_path="/tmp/test-config.yaml",
+        )
+        with patch("bioos.cli.main.resolve_auth_settings", return_value={
+            "access_key": "ak-value",
+            "secret_key": "sk-value",
+            "endpoint": "https://bio-top.miracle.ac.cn",
+            "region": None,
+        }), \
+                patch("bioos.cli.config_store.update_section_values", return_value=Path("/tmp/test-config.yaml")), \
+                patch("bioos.cli.main._handle_auth_status", return_value={
+                    "success": True,
+                    "login_status": "Logged in",
+                }), \
+                patch("bioos.cli.main._handle_aai_login", return_value={
+                    "synced": True,
+                    "saved": [{"section": "main_web"}, {"section": "repo"}, {"section": "datasite"}],
+                }) as aai_login_mock:
+            result = cli_main._handle_auth_connect_aai(args)
+        self.assertTrue(result["synced"])
+        self.assertEqual(result["saved"][0]["section"], "client")
+        self.assertEqual(result["saved"][1]["section"], "main_web")
+        aai_login_mock.assert_called_once()
+
+    def test_build_repository_client_rejects_expired_config_passport(self):
+        expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        with patch("bioos.ops.auth.load_repo_config", return_value={
+            "url": "https://network.miracle.ac.cn",
+            "token": "repo-token",
+            "passport_expires_at": expired,
+        }):
+            with self.assertRaises(ValueError) as exc:
+                auth_ops.build_repository_client()
+        self.assertIn("expired", str(exc.exception))
+        self.assertIn("bioos aai refresh", str(exc.exception))
+
+    def test_build_repository_client_allows_explicit_token_even_if_config_expired(self):
+        expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        with patch("bioos.ops.auth.load_repo_config", return_value={
+            "url": "https://network.miracle.ac.cn",
+            "token": "repo-token",
+            "passport_expires_at": expired,
+        }):
+            client = auth_ops.build_repository_client(token="explicit-token")
+        self.assertEqual(client.token, "explicit-token")
+
+    def test_datasite_dataset_create_accepts_cookie(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "datasite",
+                "dataset",
+                "create",
+                "--json",
+                '{"name":"demo"}',
+                "--token",
+                "passport-token",
+                "--cookie",
+                "ory_kratos_session=session-value",
+            ]
+        )
+        self.assertEqual(args.token, "passport-token")
+        self.assertEqual(args.cookie, "ory_kratos_session=session-value")
+        self.assertIs(args.handler, cli_main._handle_datasite_dataset_create)
+
+    def test_datasite_dataset_check_create_accepts_cookie(self):
+        parser = cli_main.build_parser()
+        args = parser.parse_args(
+            [
+                "datasite",
+                "dataset",
+                "check-create",
+                "--name",
+                "demo-dataset",
+                "--cookie",
+                "ory_kratos_session=session-value",
+            ]
+        )
+        self.assertEqual(args.name, "demo-dataset")
+        self.assertEqual(args.cookie, "ory_kratos_session=session-value")
+        self.assertIs(args.handler, cli_main._handle_datasite_dataset_check)
+
+    def test_handle_datasite_dataset_template_create(self):
+        args = SimpleNamespace(kind="create")
+        result = cli_main._handle_datasite_dataset_template(args)
+        self.assertEqual(result["kind"], "create")
+        self.assertIn("template", result)
+        self.assertEqual(result["template"]["name"], "mc-dataset-demo")
+
+    def test_handle_datasite_dataset_template_invalid_kind(self):
+        args = SimpleNamespace(kind="unknown-template")
+        with self.assertRaises(ValueError):
+            cli_main._handle_datasite_dataset_template(args)
+
+    def test_handle_datasite_dataset_template_upsert_files(self):
+        args = SimpleNamespace(kind="upsert-files")
+        result = cli_main._handle_datasite_dataset_template(args)
+        self.assertEqual(result["kind"], "upsert-files")
+        template = result["template"]
+        self.assertTrue(template["duplicatedReplace"])
+        self.assertIn("dataFiles", template)
+        self.assertEqual(template["dataFiles"][0]["fileType"], "FASTQ")
+        self.assertIn("accessURL", template["dataFiles"][0])
+
     def test_list_bioos_workspaces_handle(self):
         args = SimpleNamespace(page_size=1, ak="ak", sk="sk", endpoint="ep")
         fake_df = MagicMock()


### PR DESCRIPTION

## 变更概述

本 PR 为 `pybioos` 增加了面向 BioOS 主站、资源仓库和数据站点的一体化 CLI 能力，重点补齐了从主站登录、AAI passport 换票、数据集查询，到 DRS 解析和文件下载的完整链路。

---

## 主要内容

- 新增 BioOS 主站账号密码登录能力
- 新增 AAI 账号关联预检查，未关联时提前给出明确提示
- 新增 repository / datasite passport 获取、保存、刷新与过期管理
- 新增 repository / datasite service client
- 扩展 datasite 数据集与数据文件相关 CLI
- 新增 DRS 解析与单文件下载命令
- 新增按数据集筛选文件并批量下载命令
- 补充 datasite 示例模板与 README 端到端示例

---

## 新增 / 重要命令

认证相关：

- `bioos aai login`
- `bioos aai refresh`
- `bioos aai status`
- `bioos auth connect-aai`

数据访问相关：

- `bioos datasite dataset list`
- `bioos datasite dataset files`
- `bioos datasite file list-drs`
- `bioos datasite drs resolve`
- `bioos datasite drs download`
- `bioos datasite dataset download-files`

---

## 体验改进

- 支持从主站网页登录态直接换取 AAI passport
- 保存 `passport_issued_at` / `passport_expires_at`
- passport 过期时给出明确刷新提示
- 支持从数据集直接筛选目标文件并批量下载
- README 中补充了从登录到下载的完整数据链路示例

---

## 验证情况

- 单元测试通过：`106 passed`
- 已实际验证：
  - 主站登录
  - passport 获取
  - 数据集查询
  - 文件列表查询
  - DRS 解析
  - DRS 文件下载

---

## 影响文件

- `bioos/cli/main.py`
- `bioos/ops/auth.py`
- `bioos/service/main_web.py`
- `bioos/service/repository.py`
- `bioos/service/datasite.py`
- `bioos/service/rest_base.py`
- `bioos/cli/config_store.py`
- `tests/test_cli_unit.py`
- `examples/datasite/*`
- `README.md`

---

如果你想，我还可以再给你一版**“适合直接作为 GitHub Release Notes 的中文摘要版”**，会更偏用户视角而不是开发视角。