### PR TITLE
feat(network): add BioOS Network dataset and DRS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python SDK and CLI for Bio-OS.
 bioos --help
 ```
 
-The CLI is organized by resource groups such as `workspace`, `workflow`, `submission`, `file`, `ies`, `dockstore`, and `docker`.
+The CLI is organized by resource groups such as `workspace`, `workflow`, `submission`, `file`, `network`, `ies`, `dockstore`, and `docker`.
 
 ## Highlights
 
@@ -21,6 +21,7 @@ This release expands the unified `bioos` CLI in three main areas:
 - resilient workspace file upload with checkpoint resume and retry support
 - workspace member management commands
 - account-level usage and resource query commands
+- BioOS Network dataset discovery with GA4GH DRS object lookup
 
 It also makes workflow local-file preprocessing more robust and allows downloads from current-workspace `s3://...` paths.
 
@@ -68,7 +69,13 @@ client:
   MIRACLE_SECRET_KEY: "your-secret-key"
   serveraddr: "https://bio-top.miracle.ac.cn"
   region: "cn-north-1"
+  repository_endpoint: "https://network.miracle.ac.cn"
+  drs_endpoint: "http://imc-drs.miracle.ac.cn"
 ```
+
+`repository_endpoint` and `drs_endpoint` have these same defaults in the SDK,
+so they only need to be written when your deployment uses different Network or
+DRS endpoints.
 
 You can inspect the resolved auth status with:
 
@@ -200,6 +207,43 @@ bioos usage resource-total \
   --end-time 1776301200
 ```
 
+List BioOS Network datasets:
+
+```bash
+bioos network dataset list \
+  --search-word RNA \
+  --display-level Full
+```
+
+List files under a dataset:
+
+```bash
+bioos network dataset files \
+  --data-set-id <data-set-id> \
+  --data-library-id <data-library-id>
+```
+
+Get file IDs under a dataset:
+
+```bash
+bioos network dataset file-ids \
+  --data-set-id <data-set-id> \
+  --data-library-id <data-library-id>
+```
+
+Resolve a GA4GH DRS object:
+
+```bash
+bioos network drs --object-id <object-id>
+```
+
+Get a DRS access URL or download a DRS object:
+
+```bash
+bioos network drs access --object-id <object-id> --access-id https
+bioos network drs download --object-id <object-id> --target ./downloads/
+```
+
 ## CLI Overview
 
 Top-level command groups:
@@ -210,6 +254,7 @@ Top-level command groups:
 - `bioos workflow`
 - `bioos submission`
 - `bioos file`
+- `bioos network`
 - `bioos ies`
 - `bioos dockstore`
 - `bioos docker`
@@ -250,6 +295,18 @@ Current file commands:
 - `bioos file list`
 - `bioos file download`
 - `bioos file delete`
+
+Current Network commands:
+
+- `bioos network dataset list`
+- `bioos network dataset get`
+- `bioos network dataset files`
+- `bioos network dataset file-ids`
+- `bioos network dataset download-files`
+- `bioos network dataset drs`
+- `bioos network drs`
+- `bioos network drs access`
+- `bioos network drs download`
 
 Current usage commands:
 

--- a/bioos/__about__.py
+++ b/bioos/__about__.py
@@ -1,4 +1,4 @@
 # coding:utf-8
 
 # Package version
-__version__ = "0.0.23"
+__version__ = "0.0.24"

--- a/bioos/bioos.py
+++ b/bioos/bioos.py
@@ -2,6 +2,7 @@ from pandas import DataFrame
 from volcengine.const.Const import REGION_CN_NORTH1
 
 from bioos.config import Config,DEFAULT_ENDPOINT
+from bioos.resource.network import NetworkResource
 from bioos.resource.usage import UsageResource
 from bioos.resource.utility import UtilityResource
 from bioos.resource.workspaces import Workspace
@@ -123,3 +124,12 @@ def usage() -> UsageResource:
     :rtype: UsageResource
     """
     return UsageResource()
+
+
+def network() -> NetworkResource:
+    """Returns the account-level BioOS Network resource domain.
+
+    :return: Network resource object
+    :rtype: NetworkResource
+    """
+    return NetworkResource()

--- a/bioos/cli/config_store.py
+++ b/bioos/cli/config_store.py
@@ -10,6 +10,8 @@ EXAMPLE_CONFIG = """client:
   MIRACLE_SECRET_KEY: "SKxxxx"
   serveraddr: "https://bio-top.miracle.ac.cn"
   region: "cn-north-1"
+  repository_endpoint: "https://network.miracle.ac.cn"
+  drs_endpoint: "http://imc-drs.miracle.ac.cn"
 """
 
 

--- a/bioos/cli/dataset.py
+++ b/bioos/cli/dataset.py
@@ -1,0 +1,311 @@
+import sys
+
+from bioos.cli.common import add_argument, add_bool_argument, build_parser, run_cli
+from bioos.ops.auth import login_with_args
+from bioos.ops.formatters import dataframe_records
+
+
+def build_list_args():
+    parser = build_parser("List BioOS Network data sets.")
+    add_dataset_list_arguments(parser)
+    return parser
+
+
+def build_files_args():
+    parser = build_parser("List files under a BioOS Network data set.")
+    add_dataset_files_arguments(parser)
+    return parser
+
+
+def build_get_args():
+    parser = build_parser("Get a BioOS Network data set.")
+    add_dataset_get_arguments(parser)
+    return parser
+
+
+def build_file_ids_args():
+    parser = build_parser("List file IDs under a BioOS Network data set.")
+    add_dataset_file_ids_arguments(parser)
+    return parser
+
+
+def build_download_files_args():
+    parser = build_parser("Download files under a BioOS Network data set.")
+    add_dataset_download_files_arguments(parser)
+    return parser
+
+
+def build_drs_args():
+    parser = build_parser("Get a GA4GH DRS object.")
+    add_drs_arguments(parser)
+    return parser
+
+
+def build_drs_access_args():
+    parser = build_parser("Get a GA4GH DRS object access URL.")
+    add_drs_access_arguments(parser)
+    return parser
+
+
+def build_drs_download_args():
+    parser = build_parser("Download a GA4GH DRS object.")
+    add_drs_download_arguments(parser)
+    return parser
+
+
+def add_dataset_list_arguments(parser):
+    add_argument(parser, "page", required=False, type=int, help="Page number.")
+    add_argument(parser, "size", required=False, type=int, help="Page size.")
+    add_argument(parser, "order_by", required=False, help="Order expression, e.g. createTime:desc,name:asc.")
+    add_argument(parser, "search_word", required=False, help="Data set name search word.")
+    add_argument(parser, "data_library_id", required=False, help="Data library ID.")
+    add_argument(parser, "id", required=False, action="append", help="Data set ID. Can be specified multiple times.")
+    add_argument(parser, "access_control", required=False, help="Data set access control.")
+    add_argument(
+        parser,
+        "project_data_type",
+        required=False,
+        action="append",
+        help="Project data type. Can be specified multiple times.",
+    )
+    add_argument(parser, "category", required=False, action="append", help="Category. Can be specified multiple times.")
+    add_argument(parser, "user_id", required=False, help="User ID.")
+    add_argument(parser, "catalogue", required=False, action="append", help="Catalogue. Can be specified multiple times.")
+    add_argument(parser, "display_level", required=False, help="Display level: Minimal or Full.")
+    add_argument(parser, "group", required=False, help="Data access committee/group.")
+    add_argument(parser, "data_file_id", required=False, help="Data file ID.")
+
+
+def add_dataset_get_arguments(parser):
+    add_argument(parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(parser, "data_library_id", required=False, help="Data library ID.")
+    add_argument(parser, "display_level", required=False, default="Full", help="Display level: Minimal or Full.")
+
+
+def add_dataset_files_arguments(parser):
+    add_argument(parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(parser, "data_library_id", required=True, help="Data library ID.")
+    add_argument(parser, "page", required=False, type=int, help="Page number.")
+    add_argument(parser, "size", required=False, type=int, help="Page size.")
+    add_argument(parser, "order_by", required=False, help="Order expression, e.g. createTime:desc,name:asc.")
+    add_argument(
+        parser,
+        "search_scope",
+        required=False,
+        action="append",
+        help="Search scope. Can be specified multiple times.",
+    )
+    add_argument(parser, "search_word", required=False, help="Data file search word.")
+    add_argument(parser, "time_search_scope", required=False, help="Time search scope: create_time or update_time.")
+    add_argument(parser, "start_time", required=False, type=int, help="Time search start timestamp.")
+    add_argument(parser, "end_time", required=False, type=int, help="Time search end timestamp.")
+    add_argument(parser, "id", required=False, action="append", help="Data file ID. Can be specified multiple times.")
+    add_argument(parser, "file_type", required=False, action="append", help="File type. Can be specified multiple times.")
+
+
+def add_dataset_file_ids_arguments(parser):
+    add_argument(parser, "data_set_id", required=True, help="Data set ID.")
+    add_argument(parser, "data_library_id", required=True, help="Data library ID.")
+    add_argument(
+        parser,
+        "search_scope",
+        required=False,
+        action="append",
+        help="Search scope. Can be specified multiple times.",
+    )
+    add_argument(parser, "search_word", required=False, help="Data file search word.")
+    add_argument(parser, "time_search_scope", required=False, help="Time search scope: create_time or update_time.")
+    add_argument(parser, "start_time", required=False, type=int, help="Time search start timestamp.")
+    add_argument(parser, "end_time", required=False, type=int, help="Time search end timestamp.")
+    add_argument(parser, "id", required=False, action="append", help="Data file ID. Can be specified multiple times.")
+    add_argument(parser, "file_type", required=False, action="append", help="File type. Can be specified multiple times.")
+
+
+def add_dataset_download_files_arguments(parser):
+    add_dataset_files_arguments(parser)
+    add_argument(parser, "target", required=True, help="Local target directory.")
+    add_argument(parser, "access_id", required=False, default="https", help="DRS access ID. Defaults to https.")
+    add_bool_argument(parser, "overwrite", default=False, help_text="Overwrite existing local files.")
+    add_bool_argument(parser, "continue_on_error", default=False, help_text="Continue downloading remaining files after a failure.")
+
+
+def add_drs_arguments(parser, required=True):
+    add_argument(parser, "object_id", required=required, help="DRS object ID or drs:// URI.")
+
+
+def add_drs_access_arguments(parser):
+    add_drs_arguments(parser)
+    add_argument(parser, "access_id", required=False, default="https", help="DRS access ID. Defaults to https.")
+
+
+def add_drs_download_arguments(parser):
+    add_drs_access_arguments(parser)
+    add_argument(parser, "target", required=False, default=".", help="Local target file path or directory.")
+    add_bool_argument(parser, "overwrite", default=False, help_text="Overwrite an existing local file.")
+
+
+def handle_list(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    data_sets = bioos.network().datasets.list(
+        page=args.page,
+        size=args.size,
+        order_by=args.order_by,
+        search_word=args.search_word,
+        data_library_id=args.data_library_id,
+        ids=args.id,
+        access_control=args.access_control,
+        project_data_type=args.project_data_type,
+        category=args.category,
+        user_id=args.user_id,
+        catalogue=args.catalogue,
+        display_level=args.display_level,
+        group=args.group,
+        data_file_id=args.data_file_id,
+    )
+    return dataframe_records(data_sets)
+
+
+def handle_get(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    return bioos.network().dataset(args.data_set_id, data_library_id=args.data_library_id).get(
+        display_level=args.display_level,
+    )
+
+
+def handle_files(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    files = bioos.network().dataset(args.data_set_id, data_library_id=args.data_library_id).files(
+        page=args.page,
+        size=args.size,
+        order_by=args.order_by,
+        search_scope=args.search_scope,
+        search_word=args.search_word,
+        time_search_scope=args.time_search_scope,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        ids=args.id,
+        file_type=args.file_type,
+    )
+    return dataframe_records(files)
+
+
+def handle_file_ids(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    ids = bioos.network().dataset(args.data_set_id, data_library_id=args.data_library_id).file_ids(
+        search_scope=args.search_scope,
+        search_word=args.search_word,
+        time_search_scope=args.time_search_scope,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        ids=args.id,
+        file_type=args.file_type,
+    )
+    return {"ids": ids}
+
+
+def handle_download_files(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    return bioos.network().dataset(args.data_set_id, data_library_id=args.data_library_id).download_files(
+        target=args.target,
+        access_id=args.access_id,
+        overwrite=args.overwrite,
+        continue_on_error=args.continue_on_error,
+        page=args.page,
+        size=args.size,
+        order_by=args.order_by,
+        search_scope=args.search_scope,
+        search_word=args.search_word,
+        time_search_scope=args.time_search_scope,
+        start_time=args.start_time,
+        end_time=args.end_time,
+        ids=args.id,
+        file_type=args.file_type,
+    )
+
+
+def handle_drs(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    return bioos.network().drs_object(args.object_id)
+
+
+def handle_drs_access(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    return bioos.network().drs_access(args.object_id, access_id=args.access_id)
+
+
+def handle_drs_download(args):
+    from bioos import bioos
+
+    login_with_args(args)
+    return bioos.network().download_drs_object(
+        args.object_id,
+        target=args.target,
+        access_id=args.access_id,
+        overwrite=args.overwrite,
+    )
+
+
+def main_list():
+    parser = build_list_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_list, args))
+
+
+def main_get():
+    parser = build_get_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_get, args))
+
+
+def main_files():
+    parser = build_files_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_files, args))
+
+
+def main_file_ids():
+    parser = build_file_ids_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_file_ids, args))
+
+
+def main_download_files():
+    parser = build_download_files_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_download_files, args))
+
+
+def main_drs():
+    parser = build_drs_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_drs, args))
+
+
+def main_drs_access():
+    parser = build_drs_access_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_drs_access, args))
+
+
+def main_drs_download():
+    parser = build_drs_download_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle_drs_download, args))
+
+
+if __name__ == "__main__":
+    main_list()

--- a/bioos/cli/main.py
+++ b/bioos/cli/main.py
@@ -10,6 +10,7 @@ from bioos.cli import (
     check_ies_status,
     create_iesapp,
     create_workspace_bioos,
+    dataset,
     delete_workspace_members,
     delete_submission,
     download_files_from_workspace,
@@ -49,6 +50,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_workflow_group(subparsers)
     _add_submission_group(subparsers)
     _add_file_group(subparsers)
+    _add_network_group(subparsers)
     _add_usage_group(subparsers)
     _add_ies_group(subparsers)
     _add_dockstore_group(subparsers)
@@ -487,6 +489,86 @@ def _add_file_group(subparsers: Any) -> None:
     add_bool_argument(download_parser, "flatten", default=False, help_text="Flatten directories during download.")
     download_parser.set_defaults(_parser=download_parser)
     download_parser.set_defaults(handler=download_files_from_workspace.handle)
+
+
+def _add_network_group(subparsers: Any) -> None:
+    network_parser = subparsers.add_parser("network", help="BioOS Network repository commands.")
+    network_subparsers = network_parser.add_subparsers(dest="network_command")
+    network_parser.set_defaults(_parser=network_parser)
+
+    dataset_parser = network_subparsers.add_parser("dataset", help="BioOS Network data set commands.")
+    dataset_parser.set_defaults(_parser=dataset_parser)
+    _add_dataset_subcommands(dataset_parser.add_subparsers(dest="network_dataset_command"))
+
+    drs_parser = network_subparsers.add_parser("drs", help="GA4GH DRS object commands.")
+    add_auth_arguments(drs_parser)
+    add_output_arguments(drs_parser)
+    dataset.add_drs_arguments(drs_parser, required=False)
+    drs_parser.set_defaults(_parser=drs_parser)
+    drs_parser.set_defaults(handler=dataset.handle_drs)
+
+    drs_subparsers = drs_parser.add_subparsers(dest="network_drs_command")
+
+    access_parser = drs_subparsers.add_parser("access", help="Get a GA4GH DRS object access URL.")
+    add_auth_arguments(access_parser)
+    add_output_arguments(access_parser)
+    dataset.add_drs_access_arguments(access_parser)
+    access_parser.set_defaults(_parser=access_parser)
+    access_parser.set_defaults(handler=dataset.handle_drs_access)
+
+    download_parser = drs_subparsers.add_parser("download", help="Download a GA4GH DRS object.")
+    add_auth_arguments(download_parser)
+    add_output_arguments(download_parser)
+    dataset.add_drs_download_arguments(download_parser)
+    download_parser.set_defaults(_parser=download_parser)
+    download_parser.set_defaults(handler=dataset.handle_drs_download)
+
+
+def _add_dataset_subcommands(dataset_subparsers: Any) -> None:
+    list_parser = dataset_subparsers.add_parser("list", help="List BioOS Network data sets.")
+    add_auth_arguments(list_parser)
+    add_output_arguments(list_parser)
+    dataset.add_dataset_list_arguments(list_parser)
+    list_parser.set_defaults(_parser=list_parser)
+    list_parser.set_defaults(handler=dataset.handle_list)
+
+    get_parser = dataset_subparsers.add_parser("get", help="Get one BioOS Network data set.")
+    add_auth_arguments(get_parser)
+    add_output_arguments(get_parser)
+    dataset.add_dataset_get_arguments(get_parser)
+    get_parser.set_defaults(_parser=get_parser)
+    get_parser.set_defaults(handler=dataset.handle_get)
+
+    files_parser = dataset_subparsers.add_parser("files", help="List files under a BioOS Network data set.")
+    add_auth_arguments(files_parser)
+    add_output_arguments(files_parser)
+    dataset.add_dataset_files_arguments(files_parser)
+    files_parser.set_defaults(_parser=files_parser)
+    files_parser.set_defaults(handler=dataset.handle_files)
+
+    file_ids_parser = dataset_subparsers.add_parser("file-ids", help="List file IDs under a BioOS Network data set.")
+    add_auth_arguments(file_ids_parser)
+    add_output_arguments(file_ids_parser)
+    dataset.add_dataset_file_ids_arguments(file_ids_parser)
+    file_ids_parser.set_defaults(_parser=file_ids_parser)
+    file_ids_parser.set_defaults(handler=dataset.handle_file_ids)
+
+    download_files_parser = dataset_subparsers.add_parser(
+        "download-files",
+        help="Download files under a BioOS Network data set.",
+    )
+    add_auth_arguments(download_files_parser)
+    add_output_arguments(download_files_parser)
+    dataset.add_dataset_download_files_arguments(download_files_parser)
+    download_files_parser.set_defaults(_parser=download_files_parser)
+    download_files_parser.set_defaults(handler=dataset.handle_download_files)
+
+    drs_parser = dataset_subparsers.add_parser("drs", help="Get GA4GH DRS object information.")
+    add_auth_arguments(drs_parser)
+    add_output_arguments(drs_parser)
+    dataset.add_drs_arguments(drs_parser)
+    drs_parser.set_defaults(_parser=drs_parser)
+    drs_parser.set_defaults(handler=dataset.handle_drs)
 
 
 def _add_ies_group(subparsers: Any) -> None:

--- a/bioos/internal/repository.py
+++ b/bioos/internal/repository.py
@@ -1,0 +1,379 @@
+import ast
+import json
+import os
+import time
+from collections import OrderedDict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import quote, urlencode, urlparse
+
+import requests
+from volcengine.Credentials import Credentials
+from volcengine.auth.SignerV4 import SignerV4
+from volcengine.base.Request import Request
+
+from bioos.config import Config
+from bioos.errors import ConfigurationError
+
+
+DEFAULT_PASSPORT_EXPIRES_IN = 3600
+PASSPORT_REFRESH_MARGIN = 60
+DEFAULT_REPOSITORY_ENDPOINT = "https://network.miracle.ac.cn"
+DEFAULT_DRS_ENDPOINT = "http://imc-drs.miracle.ac.cn"
+
+
+def resolve_repository_endpoint(endpoint: Optional[str] = None) -> str:
+    return _resolve_endpoint(
+        explicit=endpoint,
+        env_name="BIOOS_REPOSITORY_ENDPOINT",
+        config_names=("repository_endpoint", "repositoryaddr"),
+        default_endpoint=DEFAULT_REPOSITORY_ENDPOINT,
+    )
+
+
+def resolve_drs_endpoint(endpoint: Optional[str] = None) -> str:
+    return _resolve_endpoint(
+        explicit=endpoint,
+        env_name="BIOOS_DRS_ENDPOINT",
+        config_names=("drs_endpoint", "drsaddr"),
+        default_endpoint=DEFAULT_DRS_ENDPOINT,
+    )
+
+
+def _resolve_endpoint(explicit: Optional[str], env_name: str, config_names, default_endpoint: str) -> str:
+    value = explicit or os.getenv(env_name)
+    if not value:
+        client_config = _load_client_config()
+        for name in config_names:
+            if client_config.get(name):
+                value = client_config[name]
+                break
+    if not value:
+        value = default_endpoint
+    if not value:
+        raise ConfigurationError(env_name)
+    return value.rstrip("/")
+
+
+def _load_client_config() -> Dict[str, Any]:
+    try:
+        from bioos.cli.config_store import load_client_config
+
+        return load_client_config()
+    except Exception:
+        return {}
+
+
+class RepositoryPassportProvider:
+    TOKEN_KEYS = ("AAIPassport", "Passport", "Token", "AccessToken", "access_token", "token")
+    EXPIRES_AT_KEYS = ("ExpiresAt", "ExpiredAt", "ExpireTime", "ExpiredTime", "expires_at", "expired_at")
+    EXPIRES_IN_KEYS = ("ExpiresIn", "ExpireIn", "expires_in", "expire_in")
+
+    def __init__(
+        self,
+        expires_in: int = DEFAULT_PASSPORT_EXPIRES_IN,
+        refresh_margin: int = PASSPORT_REFRESH_MARGIN,
+    ):
+        self.expires_in = int(expires_in)
+        self.refresh_margin = int(refresh_margin)
+        self._token = None
+        self._expires_at = 0.0
+        self._cache_key = None
+
+    def get_token(self, force_refresh: bool = False) -> str:
+        cache_key = self._current_cache_key()
+        now = time.time()
+        if (
+            not force_refresh
+            and self._token
+            and self._cache_key == cache_key
+            and now < self._expires_at - self.refresh_margin
+        ):
+            return self._token
+
+        params = {"ExpiresIn": self.expires_in} if self.expires_in else {}
+        try:
+            payload = Config.service().get_repository_passport(params)
+        except Exception as exc:
+            raise _repository_passport_error(exc) from exc
+        token = self._extract_token(payload)
+        self._token = token
+        self._cache_key = cache_key
+        self._expires_at = self._extract_expires_at(payload, now)
+        return token
+
+    def _current_cache_key(self):
+        login_info = Config.login_info()
+        return login_info.endpoint, login_info.region, login_info.access_key
+
+    def _extract_token(self, payload: Dict[str, Any]) -> str:
+        if not isinstance(payload, dict):
+            raise RuntimeError("GetRepositoryPassport returned an invalid response.")
+        for key in self.TOKEN_KEYS:
+            value = payload.get(key)
+            if value:
+                return str(value)
+        raise RuntimeError(
+            "GetRepositoryPassport did not return a passport token. "
+            f"Expected one of: {', '.join(self.TOKEN_KEYS)}."
+        )
+
+    def _extract_expires_at(self, payload: Dict[str, Any], now: float) -> float:
+        for key in self.EXPIRES_AT_KEYS:
+            value = payload.get(key)
+            if value:
+                parsed = _parse_expiry(value)
+                if parsed:
+                    return parsed
+        for key in self.EXPIRES_IN_KEYS:
+            value = payload.get(key)
+            if value:
+                try:
+                    return now + int(value)
+                except (TypeError, ValueError):
+                    pass
+        return now + self.expires_in
+
+
+class RepositoryRestClient:
+    def __init__(
+        self,
+        endpoint: str,
+        passport_provider: Optional[RepositoryPassportProvider] = None,
+        sign_requests: bool = True,
+        service_name: str = "bio",
+        region: Optional[str] = None,
+        timeout: int = 60,
+        session: Optional[requests.Session] = None,
+    ):
+        self.endpoint = endpoint.rstrip("/")
+        self.passport_provider = passport_provider or RepositoryPassportProvider()
+        self.sign_requests = sign_requests
+        self.service_name = service_name
+        self.region = region
+        self.timeout = timeout
+        self.session = session or requests.Session()
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return self.request("GET", path, params=params)
+
+    def post(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return self.request("POST", path, params=params, body=body)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        method = method.upper()
+        body_text = json.dumps(body, ensure_ascii=False) if body is not None else ""
+        query = _normalize_query_params(params or {})
+        full_path = self._full_path(path)
+        if self.sign_requests:
+            query = self._signed_query(method, full_path, query, body_text)
+
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.passport_provider.get_token()}",
+        }
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        response = self.session.request(
+            method,
+            self._url(full_path, query),
+            headers=headers,
+            data=body_text if body is not None else None,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return {}
+        return response.json()
+
+    def download_url(
+        self,
+        url: str,
+        target_path: str,
+        headers: Optional[Dict[str, str]] = None,
+        chunk_size: int = 1024 * 1024,
+    ) -> Dict[str, Any]:
+        if not url:
+            raise ValueError("download url is required")
+
+        target = Path(target_path).expanduser()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        response = self.session.request(
+            "GET",
+            url,
+            headers=headers or {},
+            stream=True,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+        bytes_written = 0
+        with target.open("wb") as handle:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if not chunk:
+                    continue
+                handle.write(chunk)
+                bytes_written += len(chunk)
+
+        return {
+            "target": str(target),
+            "bytes_written": bytes_written,
+        }
+
+    def _signed_query(self, method: str, path: str, query: OrderedDict, body_text: str) -> OrderedDict:
+        request = Request()
+        request.set_shema(urlparse(self.endpoint).scheme)
+        request.set_method(method)
+        request.set_path(path)
+        request.set_query(OrderedDict(query))
+        request.body = body_text
+        SignerV4.sign_url(request, self._credentials())
+        return request.query
+
+    def _credentials(self) -> Credentials:
+        login_info = Config.login_info()
+        if not login_info.access_key:
+            raise ConfigurationError("ACCESS_KEY")
+        if not login_info.secret_key:
+            raise ConfigurationError("SECRET_KEY")
+        region = self.region or login_info.region
+        if not region:
+            raise ConfigurationError("REGION")
+        return Credentials(login_info.access_key, login_info.secret_key, self.service_name, region)
+
+    def _full_path(self, path: str) -> str:
+        parsed = urlparse(self.endpoint)
+        base_path = parsed.path.rstrip("/")
+        api_path = "/" + path.lstrip("/")
+        return f"{base_path}{api_path}" if base_path else api_path
+
+    def _url(self, path: str, query: OrderedDict) -> str:
+        parsed = urlparse(self.endpoint)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        encoded_query = urlencode(query, doseq=True)
+        if encoded_query:
+            return f"{base_url}{path}?{encoded_query}"
+        return f"{base_url}{path}"
+
+
+def _normalize_query_params(params: Dict[str, Any]) -> OrderedDict:
+    query = OrderedDict()
+    for key, value in params.items():
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)):
+            values = [str(item) for item in value if item is not None]
+            if values:
+                query[key] = values
+        else:
+            query[key] = str(value)
+    return query
+
+
+def _parse_expiry(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        timestamp = float(value)
+        if timestamp > 10_000_000_000:
+            timestamp /= 1000.0
+        return timestamp
+
+    if not isinstance(value, str):
+        return None
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return _parse_expiry(float(stripped))
+    except ValueError:
+        pass
+
+    try:
+        normalized = stripped.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return None
+
+
+def quote_path_segment(value: str) -> str:
+    return quote(str(value).strip(), safe="")
+
+
+def _repository_passport_error(exc: Exception) -> RuntimeError:
+    backend_error = _parse_backend_error(exc)
+    if backend_error:
+        code = backend_error.get("Code") or "Unknown"
+        message = str(backend_error.get("Message") or str(exc)).rstrip(".")
+        request_id = backend_error.get("RequestId")
+        request_id_text = f" RequestId: {request_id}." if request_id else ""
+        return RuntimeError(
+            "Unable to obtain BioOS Network AAAI passport. "
+            "Please make sure the current BioOS account is associated with a BioOS Network account. "
+            f"Backend error: {code} - {message}.{request_id_text}"
+        )
+
+    return RuntimeError(
+        "Unable to obtain BioOS Network AAAI passport. "
+        "Please make sure the current BioOS account is associated with a BioOS Network account. "
+        f"Original error: {exc}"
+    )
+
+
+def _parse_backend_error(exc: Exception) -> Optional[Dict[str, Any]]:
+    text = str(exc)
+    payload = _loads_possible_bytes_json(text)
+    if not isinstance(payload, dict):
+        return None
+
+    metadata = payload.get("ResponseMetadata")
+    if not isinstance(metadata, dict):
+        return None
+
+    error = metadata.get("Error")
+    if not isinstance(error, dict):
+        return None
+
+    parsed = dict(error)
+    if metadata.get("RequestId"):
+        parsed["RequestId"] = metadata.get("RequestId")
+    return parsed
+
+
+def _loads_possible_bytes_json(text: str) -> Optional[Dict[str, Any]]:
+    raw = text
+    try:
+        literal = ast.literal_eval(text)
+        if isinstance(literal, bytes):
+            raw = literal.decode("utf-8", errors="replace")
+        elif isinstance(literal, str):
+            raw = literal
+    except (SyntaxError, ValueError):
+        pass
+
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                return json.loads(raw[start:end + 1])
+            except ValueError:
+                return None
+    return None

--- a/bioos/resource/datasets.py
+++ b/bioos/resource/datasets.py
@@ -1,0 +1,563 @@
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+from urllib.parse import urlparse
+
+import pandas as pd
+from pandas import DataFrame
+
+from bioos.errors import NotFoundError, ParameterError
+from bioos.internal.repository import (
+    RepositoryPassportProvider,
+    RepositoryRestClient,
+    quote_path_segment,
+    resolve_drs_endpoint,
+    resolve_repository_endpoint,
+)
+from bioos.utils.common_tools import SingletonType, dict_str
+
+
+DATA_SET_PARAM_ALIASES = {
+    "order_by": "orderBy",
+    "search_word": "searchWord",
+    "data_library_id": "dataLibraryID",
+    "ids": "id",
+    "access_control": "accessControl",
+    "project_data_type": "projectDataType",
+    "user_id": "userID",
+    "display_level": "displayLevel",
+    "data_file_id": "dataFileID",
+}
+
+DATA_FILE_PARAM_ALIASES = {
+    "data_library_id": "dataLibraryID",
+    "order_by": "orderBy",
+    "search_scope": "searchScope",
+    "search_word": "searchWord",
+    "time_search_scope": "timeSearchScope",
+    "start_time": "startTime",
+    "end_time": "endTime",
+    "ids": "id",
+    "file_type": "fileType",
+}
+
+DEFAULT_DRS_ACCESS_ID = "https"
+
+
+class DataSetResource(metaclass=SingletonType):
+    def __init__(
+        self,
+        repository_endpoint: Optional[str] = None,
+        drs_endpoint: Optional[str] = None,
+        passport_provider: Optional[RepositoryPassportProvider] = None,
+    ):
+        provider = passport_provider or RepositoryPassportProvider()
+        self.repository_endpoint = resolve_repository_endpoint(repository_endpoint)
+        self.drs_endpoint = resolve_drs_endpoint(drs_endpoint)
+        self.repository_client = RepositoryRestClient(
+            endpoint=self.repository_endpoint,
+            passport_provider=provider,
+            sign_requests=True,
+        )
+        self.drs_client = RepositoryRestClient(
+            endpoint=self.drs_endpoint,
+            passport_provider=provider,
+            sign_requests=False,
+        )
+
+    def __repr__(self) -> str:
+        return f"DataSetResource:\n{dict_str({'repository_endpoint': self.repository_endpoint, 'drs_endpoint': self.drs_endpoint})}"
+
+    def list(
+        self,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        search_word: Optional[str] = None,
+        data_library_id: Optional[str] = None,
+        ids: Optional[Iterable[str]] = None,
+        access_control: Optional[str] = None,
+        project_data_type: Optional[Iterable[str]] = None,
+        category: Optional[Iterable[str]] = None,
+        user_id: Optional[str] = None,
+        catalogue: Optional[Iterable[str]] = None,
+        display_level: Optional[str] = None,
+        group: Optional[str] = None,
+        data_file_id: Optional[str] = None,
+        raw: bool = False,
+        **filters,
+    ):
+        """List BioOS Network data sets.
+
+        Set ``raw=True`` to return the repository API response without
+        converting result rows to a DataFrame.
+        """
+        params = _build_params(
+            DATA_SET_PARAM_ALIASES,
+            filters,
+            page=page,
+            size=size,
+            order_by=order_by,
+            search_word=search_word,
+            data_library_id=data_library_id,
+            ids=ids,
+            access_control=access_control,
+            project_data_type=project_data_type,
+            category=category,
+            user_id=user_id,
+            catalogue=catalogue,
+            display_level=display_level,
+            group=group,
+            data_file_id=data_file_id,
+        )
+        payload = self.repository_client.get("/api/repository/data_set", params=params)
+        if raw:
+            return payload
+        return _payload_to_dataframe(payload)
+
+    def get(
+        self,
+        data_set_id: str,
+        data_library_id: Optional[str] = None,
+        display_level: str = "Full",
+        raw: bool = False,
+        **filters,
+    ):
+        """Get one BioOS Network data set by ID.
+
+        The repository API exposes this through the list endpoint with an
+        ``id`` filter, so the SDK keeps the user-facing operation as ``get``.
+        Set ``raw=True`` to return the original list payload.
+        """
+        if not data_set_id:
+            raise ParameterError("data_set_id")
+
+        payload = self.list(
+            ids=[data_set_id],
+            data_library_id=data_library_id,
+            display_level=display_level,
+            raw=True,
+            **filters,
+        )
+        if raw:
+            return payload
+
+        records = _extract_records(payload)
+        for record in records:
+            if isinstance(record, dict) and record.get("id") == data_set_id:
+                return record
+        if records:
+            return records[0]
+        raise NotFoundError("DataSet", data_set_id)
+
+    def data_set(self, data_set_id: str, data_library_id: Optional[str] = None):
+        return DataSet(
+            data_set_id=data_set_id,
+            data_library_id=data_library_id,
+            resource=self,
+        )
+
+    def drs_object(self, object_id: str) -> Dict[str, Any]:
+        object_id = _normalize_drs_object_id(object_id)
+        return self.drs_client.get(f"/ga4gh/drs/v1/objects/{quote_path_segment(object_id)}")
+
+    def drs_access(
+        self,
+        object_id: str,
+        access_id: str = DEFAULT_DRS_ACCESS_ID,
+    ) -> Dict[str, Any]:
+        object_id = _normalize_drs_object_id(object_id)
+        if not access_id:
+            raise ParameterError("access_id")
+        access = _access_from_drs_object(self.drs_object(object_id), access_id)
+        if access:
+            return access
+        return self.drs_client.get(
+            "/ga4gh/drs/v1/objects/"
+            f"{quote_path_segment(object_id)}/access/{quote_path_segment(access_id)}"
+        )
+
+    def download_drs_object(
+        self,
+        object_id: str,
+        target: str = ".",
+        access_id: str = DEFAULT_DRS_ACCESS_ID,
+        overwrite: bool = False,
+        chunk_size: int = 1024 * 1024,
+        object_info: Optional[Dict[str, Any]] = None,
+        object_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        object_id = _normalize_drs_object_id(object_id)
+        if not target:
+            raise ParameterError("target")
+
+        info = object_info if object_info is not None else self.drs_object(object_id)
+        filename = _safe_download_name(object_name or _dict_get(info, "name") or object_id)
+        target_path = _resolve_download_target(target, filename)
+        if target_path.exists() and not overwrite:
+            raise FileExistsError(f"target already exists: {target_path}")
+
+        access = _access_from_drs_object(info, access_id) or self.drs_access(object_id, access_id=access_id)
+        url = _extract_access_url(access)
+        headers = _extract_access_headers(access)
+        result = self.drs_client.download_url(
+            url,
+            str(target_path),
+            headers=headers,
+            chunk_size=chunk_size,
+        )
+        result.update(
+            {
+                "success": True,
+                "object_id": object_id,
+                "access_id": access_id,
+                "name": filename,
+            }
+        )
+        return result
+
+
+class DataSet(metaclass=SingletonType):
+    def __init__(
+        self,
+        data_set_id: str,
+        data_library_id: Optional[str] = None,
+        resource: Optional[DataSetResource] = None,
+    ):
+        if not data_set_id:
+            raise ParameterError("data_set_id")
+        self.data_set_id = data_set_id
+        self.data_library_id = data_library_id
+        self.resource = resource or DataSetResource()
+
+    def __repr__(self) -> str:
+        info = {
+            "data_set_id": self.data_set_id,
+            "data_library_id": self.data_library_id,
+        }
+        return f"DataSet:\n{dict_str(info)}"
+
+    def files(
+        self,
+        data_library_id: Optional[str] = None,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        search_scope: Optional[Iterable[str]] = None,
+        search_word: Optional[str] = None,
+        time_search_scope: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+        ids: Optional[Iterable[str]] = None,
+        file_type: Optional[Iterable[str]] = None,
+        raw: bool = False,
+        **filters,
+    ):
+        library_id = data_library_id or self.data_library_id or filters.pop("dataLibraryID", None)
+        if not library_id:
+            raise ParameterError("data_library_id")
+
+        params = _build_data_file_params(
+            library_id=library_id,
+            filters=filters,
+            page=page,
+            size=size,
+            order_by=order_by,
+            search_scope=search_scope,
+            search_word=search_word,
+            time_search_scope=time_search_scope,
+            start_time=start_time,
+            end_time=end_time,
+            ids=ids,
+            file_type=file_type,
+        )
+        payload = self.resource.repository_client.get(
+            f"/api/repository/data_set/{quote_path_segment(self.data_set_id)}/data_file",
+            params=params,
+        )
+        if raw:
+            return payload
+        return _payload_to_dataframe(payload)
+
+    def drs_object(self, object_id: str) -> Dict[str, Any]:
+        return self.resource.drs_object(object_id)
+
+    def get(self, display_level: str = "Full", raw: bool = False, **filters):
+        return self.resource.get(
+            self.data_set_id,
+            data_library_id=self.data_library_id,
+            display_level=display_level,
+            raw=raw,
+            **filters,
+        )
+
+    def file_ids(
+        self,
+        data_library_id: Optional[str] = None,
+        search_scope: Optional[Iterable[str]] = None,
+        search_word: Optional[str] = None,
+        time_search_scope: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+        ids: Optional[Iterable[str]] = None,
+        file_type: Optional[Iterable[str]] = None,
+        raw: bool = False,
+        **filters,
+    ):
+        library_id = data_library_id or self.data_library_id or filters.pop("dataLibraryID", None)
+        if not library_id:
+            raise ParameterError("data_library_id")
+
+        params = _build_data_file_params(
+            library_id=library_id,
+            filters=filters,
+            search_scope=search_scope,
+            search_word=search_word,
+            time_search_scope=time_search_scope,
+            start_time=start_time,
+            end_time=end_time,
+            ids=ids,
+            file_type=file_type,
+        )
+        payload = self.resource.repository_client.get(
+            f"/api/repository/data_set/{quote_path_segment(self.data_set_id)}/data_file/ids",
+            params=params,
+        )
+        if raw:
+            return payload
+        return _extract_ids(payload)
+
+    def download_files(
+        self,
+        target: str,
+        data_library_id: Optional[str] = None,
+        access_id: str = DEFAULT_DRS_ACCESS_ID,
+        overwrite: bool = False,
+        continue_on_error: bool = False,
+        page: Optional[int] = None,
+        size: Optional[int] = None,
+        order_by: Optional[str] = None,
+        search_scope: Optional[Iterable[str]] = None,
+        search_word: Optional[str] = None,
+        time_search_scope: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+        ids: Optional[Iterable[str]] = None,
+        file_type: Optional[Iterable[str]] = None,
+        **filters,
+    ) -> Dict[str, Any]:
+        if not target:
+            raise ParameterError("target")
+
+        payload = self.files(
+            data_library_id=data_library_id,
+            page=page,
+            size=size,
+            order_by=order_by,
+            search_scope=search_scope,
+            search_word=search_word,
+            time_search_scope=time_search_scope,
+            start_time=start_time,
+            end_time=end_time,
+            ids=ids,
+            file_type=file_type,
+            raw=True,
+            **filters,
+        )
+        records = _extract_records(payload)
+        target_dir = Path(target).expanduser()
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        downloads = []
+        failures = []
+        for record in records:
+            try:
+                object_id = _file_record_object_id(record)
+                name = _safe_download_name(_dict_get(record, "name") or object_id)
+                result = self.resource.download_drs_object(
+                    object_id,
+                    target=str(target_dir / name),
+                    access_id=access_id,
+                    overwrite=overwrite,
+                    object_info=record if isinstance(record, dict) else None,
+                    object_name=name,
+                )
+                downloads.append(result)
+            except Exception as exc:
+                failure = {
+                    "record": record,
+                    "error": str(exc),
+                }
+                failures.append(failure)
+                if not continue_on_error:
+                    raise
+
+        return {
+            "success": len(failures) == 0,
+            "data_set_id": self.data_set_id,
+            "total": len(records),
+            "downloaded_count": len(downloads),
+            "failed_count": len(failures),
+            "downloads": downloads,
+            "failures": failures,
+        }
+
+
+def _build_params(aliases: Dict[str, str], filters: Dict[str, Any], **values) -> Dict[str, Any]:
+    params = {}
+    for key, value in values.items():
+        if value is not None:
+            params[aliases.get(key, key)] = value
+    for key, value in filters.items():
+        if value is not None:
+            params[aliases.get(key, key)] = value
+    return params
+
+
+def _build_data_file_params(library_id: str, filters: Dict[str, Any], **values) -> Dict[str, Any]:
+    return _build_params(
+        DATA_FILE_PARAM_ALIASES,
+        filters,
+        data_library_id=library_id,
+        **values,
+    )
+
+
+def _payload_to_dataframe(payload: Any) -> DataFrame:
+    records = _extract_records(payload)
+    if not records:
+        return pd.DataFrame()
+    return pd.DataFrame.from_records(records)
+
+
+def _extract_records(payload: Any):
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("Items", "items", "Data", "data", "Rows", "rows", "Results", "results"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            nested = _extract_records(value)
+            if nested:
+                return nested
+    result = payload.get("Result")
+    if isinstance(result, (dict, list)):
+        return _extract_records(result)
+    return []
+
+
+def _extract_ids(payload: Any):
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("ids", "IDs", "Items", "items", "Data", "data"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            if value and isinstance(value[0], dict):
+                return [item.get("id") or item.get("ID") for item in value if item.get("id") or item.get("ID")]
+            return value
+        if isinstance(value, dict):
+            nested = _extract_ids(value)
+            if nested:
+                return nested
+    result = payload.get("Result")
+    if isinstance(result, (dict, list)):
+        return _extract_ids(result)
+    return []
+
+
+def _normalize_drs_object_id(object_id: str) -> str:
+    if not object_id:
+        raise ParameterError("object_id")
+    value = str(object_id).strip()
+    if value.startswith("drs://"):
+        parsed = urlparse(value)
+        value = parsed.path.strip("/") or parsed.netloc
+    if not value:
+        raise ParameterError("object_id")
+    return value
+
+
+def _dict_get(value: Any, key: str):
+    if isinstance(value, dict):
+        return value.get(key)
+    return None
+
+
+def _extract_access_url(access: Dict[str, Any]) -> str:
+    if not isinstance(access, dict):
+        raise RuntimeError("DRS access response is invalid.")
+    candidate = access.get("url") or access.get("URL")
+    if candidate:
+        return candidate
+    access_url = access.get("access_url") or access.get("AccessURL")
+    if isinstance(access_url, dict):
+        candidate = access_url.get("url") or access_url.get("URL")
+        if candidate:
+            return candidate
+    raise RuntimeError("DRS access response did not contain a download URL.")
+
+
+def _extract_access_headers(access: Dict[str, Any]) -> Dict[str, str]:
+    if not isinstance(access, dict):
+        return {}
+    raw_headers = access.get("headers") or access.get("Headers") or []
+    if isinstance(raw_headers, dict):
+        return {str(key): str(value) for key, value in raw_headers.items() if value is not None}
+    headers = {}
+    if isinstance(raw_headers, list):
+        for item in raw_headers:
+            if isinstance(item, dict):
+                headers.update({str(key): str(value) for key, value in item.items() if value is not None})
+                continue
+            if isinstance(item, str) and ":" in item:
+                key, value = item.split(":", 1)
+                key = key.strip()
+                if key:
+                    headers[key] = value.strip()
+    return headers
+
+
+def _access_from_drs_object(object_info: Dict[str, Any], access_id: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(object_info, dict):
+        return None
+    for method in object_info.get("access_methods") or []:
+        if not isinstance(method, dict):
+            continue
+        method_access_id = method.get("access_id") or method.get("accessId") or method.get("type")
+        if method_access_id != access_id:
+            continue
+        access_url = method.get("access_url") or method.get("accessURL") or method.get("AccessURL")
+        if isinstance(access_url, dict) and (access_url.get("url") or access_url.get("URL")):
+            return access_url
+    return None
+
+
+def _resolve_download_target(target: str, filename: str) -> Path:
+    target_path = Path(target).expanduser()
+    if str(target).endswith("/") or target_path.exists() and target_path.is_dir():
+        return target_path / filename
+    return target_path
+
+
+def _safe_download_name(name: str) -> str:
+    filename = Path(str(name)).name
+    return filename or "download"
+
+
+def _file_record_object_id(record: Any) -> str:
+    if isinstance(record, dict):
+        drs_url = record.get("drsURL") or record.get("drs_url") or record.get("DRSURL")
+        if drs_url:
+            return _normalize_drs_object_id(drs_url)
+        value = record.get("id") or record.get("ID")
+        if value:
+            return _normalize_drs_object_id(value)
+    raise ParameterError("object_id", "data file record does not include id or drsURL")

--- a/bioos/resource/network.py
+++ b/bioos/resource/network.py
@@ -1,0 +1,71 @@
+from typing import Optional
+
+from bioos.internal.repository import (
+    RepositoryPassportProvider,
+    resolve_drs_endpoint,
+    resolve_repository_endpoint,
+)
+from bioos.resource.datasets import DataSet, DataSetResource
+from bioos.utils.common_tools import SingletonType, dict_str
+
+
+class NetworkResource(metaclass=SingletonType):
+    """Account-level BioOS Network resource domain.
+
+    Network uses the existing BioOS AK/SK login to obtain a short-lived AAAI
+    passport internally, similar to how workspace files obtain TOS temporary
+    credentials before touching object storage.
+    """
+
+    def __init__(
+        self,
+        repository_endpoint: Optional[str] = None,
+        drs_endpoint: Optional[str] = None,
+        passport_provider: Optional[RepositoryPassportProvider] = None,
+    ):
+        self.repository_endpoint = resolve_repository_endpoint(repository_endpoint)
+        self.drs_endpoint = resolve_drs_endpoint(drs_endpoint)
+        self.passport_provider = passport_provider or RepositoryPassportProvider()
+
+    def __repr__(self) -> str:
+        info = {
+            "repository_endpoint": self.repository_endpoint,
+            "drs_endpoint": self.drs_endpoint,
+        }
+        return f"NetworkResource:\n{dict_str(info)}"
+
+    @property
+    def datasets(self) -> DataSetResource:
+        """Returns the BioOS Network data set resource collection."""
+        return DataSetResource(
+            repository_endpoint=self.repository_endpoint,
+            drs_endpoint=self.drs_endpoint,
+            passport_provider=self.passport_provider,
+        )
+
+    def dataset(self, data_set_id: str, data_library_id: Optional[str] = None) -> DataSet:
+        """Returns a single BioOS Network data set object."""
+        return self.datasets.data_set(data_set_id, data_library_id=data_library_id)
+
+    def drs_object(self, object_id: str):
+        """Returns GA4GH DRS object information for a Network object ID."""
+        return self.datasets.drs_object(object_id)
+
+    def drs_access(self, object_id: str, access_id: str = "https"):
+        """Returns a GA4GH DRS access URL object for a Network object ID."""
+        return self.datasets.drs_access(object_id, access_id=access_id)
+
+    def download_drs_object(
+        self,
+        object_id: str,
+        target: str = ".",
+        access_id: str = "https",
+        overwrite: bool = False,
+    ):
+        """Download a GA4GH DRS object to a local path."""
+        return self.datasets.download_drs_object(
+            object_id,
+            target=target,
+            access_id=access_id,
+            overwrite=overwrite,
+        )

--- a/bioos/service/BioOsService.py
+++ b/bioos/service/BioOsService.py
@@ -247,6 +247,11 @@ class BioOsService(Service):
                 'Action': 'GetExportWorkspacePreSignedURL',
                 'Version': '2021-03-04'
             }, {}, {}),
+            'GetRepositoryPassport':
+            ApiInfo('POST', '/', {
+                'Action': 'GetRepositoryPassport',
+                'Version': '2021-03-04'
+            }, {}, {}),
         }
         return api_info
 
@@ -372,6 +377,9 @@ class BioOsService(Service):
 
     def get_export_workspace_presigned_url(self, params):
         return self.__request("GetExportWorkspacePreSignedURL", params)
+
+    def get_repository_passport(self, params):
+        return self.__request("GetRepositoryPassport", params)
 
     def __request(self, action, params):
         res = self.json(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     install_requires=[
         "volcengine>=1.0.61", "tabulate>=0.8.10", "click>=8.0.0",
         "pandas>=1.3.0", "tos==2.5.6", "cachetools>=5.2.0",
-        "typing-extensions>=4.4.0", "apscheduler>=3.10.4", "colorama>=0.4.6"
+        "typing-extensions>=4.4.0", "apscheduler>=3.10.4", "colorama>=0.4.6",
+        "requests>=2.25.0"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -13,6 +13,7 @@ from bioos.cli import (
     check_ies_status,
     create_iesapp,
     create_workspace_bioos,
+    dataset,
     delete_workspace_members,
     delete_submission,
     download_files_from_workspace,
@@ -114,6 +115,245 @@ class TestCliHandlers(unittest.TestCase):
             result = list_files_from_workspace.handle(args)
         ws.files.list.assert_called_once_with(prefix="analysis/", recursive=True)
         self.assertEqual(result, [{"key": "a.txt"}])
+
+    def test_dataset_list_handle(self):
+        args = SimpleNamespace(
+            page=1,
+            size=10,
+            order_by="createTime:desc",
+            search_word="rna",
+            data_library_id="lib1",
+            id=["ds1", "ds2"],
+            access_control=None,
+            project_data_type=["omics"],
+            category=["rna"],
+            user_id=None,
+            catalogue=None,
+            display_level="Full",
+            group=None,
+            data_file_id=None,
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        resource = MagicMock()
+        fake_df = MagicMock()
+        network = MagicMock()
+        network.datasets.list.return_value = fake_df
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network), \
+                patch("bioos.cli.dataset.dataframe_records", return_value=[{"id": "ds1"}]):
+            result = dataset.handle_list(args)
+
+        self.assertEqual(result, [{"id": "ds1"}])
+        network.datasets.list.assert_called_once_with(
+            page=1,
+            size=10,
+            order_by="createTime:desc",
+            search_word="rna",
+            data_library_id="lib1",
+            ids=["ds1", "ds2"],
+            access_control=None,
+            project_data_type=["omics"],
+            category=["rna"],
+            user_id=None,
+            catalogue=None,
+            display_level="Full",
+            group=None,
+            data_file_id=None,
+        )
+
+    def test_dataset_get_handle(self):
+        args = SimpleNamespace(
+            data_set_id="ds1",
+            data_library_id="lib1",
+            display_level="Full",
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        data_set = MagicMock()
+        data_set.get.return_value = {"id": "ds1"}
+        network = MagicMock()
+        network.dataset.return_value = data_set
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_get(args)
+
+        self.assertEqual(result, {"id": "ds1"})
+        network.dataset.assert_called_once_with("ds1", data_library_id="lib1")
+        data_set.get.assert_called_once_with(display_level="Full")
+
+    def test_dataset_files_handle(self):
+        args = SimpleNamespace(
+            data_set_id="ds1",
+            data_library_id="lib1",
+            page=1,
+            size=20,
+            order_by="fileSize:desc",
+            search_scope=["name", "drs_url"],
+            search_word="bam",
+            time_search_scope="create_time",
+            start_time=1,
+            end_time=2,
+            id=["file1"],
+            file_type=["bam"],
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        data_set = MagicMock()
+        fake_df = MagicMock()
+        data_set.files.return_value = fake_df
+        network = MagicMock()
+        network.dataset.return_value = data_set
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network), \
+                patch("bioos.cli.dataset.dataframe_records", return_value=[{"id": "file1"}]):
+            result = dataset.handle_files(args)
+
+        self.assertEqual(result, [{"id": "file1"}])
+        network.dataset.assert_called_once_with("ds1", data_library_id="lib1")
+        data_set.files.assert_called_once_with(
+            page=1,
+            size=20,
+            order_by="fileSize:desc",
+            search_scope=["name", "drs_url"],
+            search_word="bam",
+            time_search_scope="create_time",
+            start_time=1,
+            end_time=2,
+            ids=["file1"],
+            file_type=["bam"],
+        )
+
+    def test_dataset_file_ids_handle(self):
+        args = SimpleNamespace(
+            data_set_id="ds1",
+            data_library_id="lib1",
+            search_scope=["name"],
+            search_word="fastq",
+            time_search_scope="create_time",
+            start_time=1,
+            end_time=2,
+            id=["file1"],
+            file_type=["fastq"],
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        data_set = MagicMock()
+        data_set.file_ids.return_value = ["file1"]
+        network = MagicMock()
+        network.dataset.return_value = data_set
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_file_ids(args)
+
+        self.assertEqual(result, {"ids": ["file1"]})
+        data_set.file_ids.assert_called_once_with(
+            search_scope=["name"],
+            search_word="fastq",
+            time_search_scope="create_time",
+            start_time=1,
+            end_time=2,
+            ids=["file1"],
+            file_type=["fastq"],
+        )
+
+    def test_dataset_download_files_handle(self):
+        args = SimpleNamespace(
+            data_set_id="ds1",
+            data_library_id="lib1",
+            target="/tmp/downloads",
+            access_id="https",
+            overwrite=True,
+            continue_on_error=True,
+            page=1,
+            size=20,
+            order_by="name:asc",
+            search_scope=["name"],
+            search_word="fastq",
+            time_search_scope=None,
+            start_time=None,
+            end_time=None,
+            id=["file1"],
+            file_type=["fastq"],
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        data_set = MagicMock()
+        data_set.download_files.return_value = {"success": True}
+        network = MagicMock()
+        network.dataset.return_value = data_set
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_download_files(args)
+
+        self.assertEqual(result, {"success": True})
+        data_set.download_files.assert_called_once_with(
+            target="/tmp/downloads",
+            access_id="https",
+            overwrite=True,
+            continue_on_error=True,
+            page=1,
+            size=20,
+            order_by="name:asc",
+            search_scope=["name"],
+            search_word="fastq",
+            time_search_scope=None,
+            start_time=None,
+            end_time=None,
+            ids=["file1"],
+            file_type=["fastq"],
+        )
+
+    def test_dataset_drs_handle(self):
+        args = SimpleNamespace(object_id="object-1", ak="ak", sk="sk", endpoint="ep")
+        network = MagicMock()
+        network.drs_object.return_value = {"id": "object-1"}
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_drs(args)
+
+        self.assertEqual(result, {"id": "object-1"})
+        network.drs_object.assert_called_once_with("object-1")
+
+    def test_dataset_drs_access_handle(self):
+        args = SimpleNamespace(object_id="object-1", access_id="https", ak="ak", sk="sk", endpoint="ep")
+        network = MagicMock()
+        network.drs_access.return_value = {"url": "https://download"}
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_drs_access(args)
+
+        self.assertEqual(result, {"url": "https://download"})
+        network.drs_access.assert_called_once_with("object-1", access_id="https")
+
+    def test_dataset_drs_download_handle(self):
+        args = SimpleNamespace(
+            object_id="object-1",
+            access_id="https",
+            target="/tmp/object.txt",
+            overwrite=True,
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        network = MagicMock()
+        network.download_drs_object.return_value = {"success": True}
+        with patch("bioos.cli.dataset.login_with_args"), \
+                patch("bioos.bioos.network", return_value=network):
+            result = dataset.handle_drs_download(args)
+
+        self.assertEqual(result, {"success": True})
+        network.download_drs_object.assert_called_once_with(
+            "object-1",
+            target="/tmp/object.txt",
+            access_id="https",
+            overwrite=True,
+        )
 
     def test_download_files_from_workspace_handle(self):
         args = SimpleNamespace(workspace_name="ws", source=["a.txt", "b.txt"], target="/tmp/out", flatten=True)
@@ -601,6 +841,146 @@ class TestCliRootAndAuth(unittest.TestCase):
                     "/tmp/ckpt",
                     "--max-retries",
                     "5",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_dataset_list_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_list", return_value=[{"id": "ds1"}]) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "dataset",
+                    "list",
+                    "--id",
+                    "ds1",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_dataset_get_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_get", return_value={"id": "ds1"}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "dataset",
+                    "get",
+                    "--data-set-id",
+                    "ds1",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_dataset_files_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_files", return_value=[{"id": "file1"}]) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "dataset",
+                    "files",
+                    "--data-set-id",
+                    "ds1",
+                    "--data-library-id",
+                    "lib1",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_dataset_file_ids_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_file_ids", return_value={"ids": ["file1"]}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "dataset",
+                    "file-ids",
+                    "--data-set-id",
+                    "ds1",
+                    "--data-library-id",
+                    "lib1",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_dataset_download_files_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_download_files", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "dataset",
+                    "download-files",
+                    "--data-set-id",
+                    "ds1",
+                    "--data-library-id",
+                    "lib1",
+                    "--target",
+                    "/tmp/downloads",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_drs_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_drs", return_value={"id": "object-1"}) as mocked:
+            exit_code = cli_main.main(
+                ["network", "drs", "--object-id", "object-1", "--output", "json"]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_drs_access_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_drs_access", return_value={"url": "https://download"}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "drs",
+                    "access",
+                    "--object-id",
+                    "object-1",
+                    "--access-id",
+                    "https",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_network_drs_download_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.dataset.handle_drs_download", return_value={"success": True}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "network",
+                    "drs",
+                    "download",
+                    "--object-id",
+                    "object-1",
+                    "--target",
+                    "/tmp/object.txt",
                     "--output",
                     "json",
                 ]

--- a/tests/test_ops_unit.py
+++ b/tests/test_ops_unit.py
@@ -2,11 +2,17 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import MagicMock, patch
 
+from bioos.internal.repository import RepositoryPassportProvider, RepositoryRestClient
+from bioos.internal import repository as repository_internal
 from bioos.ops import docker_build, dockstore, womtool, workspace_files
 from bioos.internal.tos import TOSHandler
 from bioos.resource.files import FileResource
+from bioos.resource.datasets import DataSet, DataSetResource
+from bioos.resource.network import NetworkResource
 from bioos.resource.usage import UsageResource
 from bioos.resource.workspaces import Workspace
 
@@ -275,6 +281,343 @@ class TestOpsHelpers(unittest.TestCase):
             "/tmp/out",
             True,
         )
+
+    def test_repository_passport_provider_caches_token(self):
+        service = MagicMock()
+        service.get_repository_passport.return_value = {"AAIPassport": "passport-1", "ExpiresIn": 3600}
+        login_info = SimpleNamespace(endpoint="https://bioos", region="cn-north-1", access_key="ak")
+        provider = RepositoryPassportProvider(expires_in=3600, refresh_margin=60)
+
+        with patch("bioos.internal.repository.Config.service", return_value=service), \
+                patch("bioos.internal.repository.Config.login_info", return_value=login_info):
+            self.assertEqual(provider.get_token(), "passport-1")
+            self.assertEqual(provider.get_token(), "passport-1")
+
+        service.get_repository_passport.assert_called_once_with({"ExpiresIn": 3600})
+
+    def test_repository_passport_provider_requires_token(self):
+        service = MagicMock()
+        service.get_repository_passport.return_value = {"ExpiresIn": 3600}
+        login_info = SimpleNamespace(endpoint="https://bioos", region="cn-north-1", access_key="ak")
+        provider = RepositoryPassportProvider()
+
+        with patch("bioos.internal.repository.Config.service", return_value=service), \
+                patch("bioos.internal.repository.Config.login_info", return_value=login_info):
+            with self.assertRaisesRegex(RuntimeError, "did not return a passport token"):
+                provider.get_token()
+
+    def test_repository_passport_provider_translates_backend_error(self):
+        service = MagicMock()
+        service.get_repository_passport.side_effect = Exception(
+            b'{"ResponseMetadata":{"RequestId":"req-1","Action":"GetRepositoryPassport",'
+            b'"Error":{"Code":"InternalError","Message":"unknown error"}}}'
+        )
+        login_info = SimpleNamespace(endpoint="https://bioos", region="cn-north-1", access_key="ak")
+        provider = RepositoryPassportProvider()
+
+        with patch("bioos.internal.repository.Config.service", return_value=service), \
+                patch("bioos.internal.repository.Config.login_info", return_value=login_info):
+            with self.assertRaisesRegex(RuntimeError, "current BioOS account is associated with a BioOS Network account"):
+                provider.get_token()
+
+    def test_repository_endpoint_defaults_are_network_endpoints(self):
+        with patch.dict("os.environ", {}, clear=True), \
+                patch("bioos.internal.repository._load_client_config", return_value={}):
+            self.assertEqual(
+                repository_internal.resolve_repository_endpoint(),
+                "https://network.miracle.ac.cn",
+            )
+            self.assertEqual(
+                repository_internal.resolve_drs_endpoint(),
+                "http://imc-drs.miracle.ac.cn",
+            )
+
+    def test_repository_rest_client_sends_bearer_and_repeated_query_params(self):
+        response = MagicMock()
+        response.content = b'{"ok": true}'
+        response.json.return_value = {"ok": True}
+        session = MagicMock()
+        session.request.return_value = response
+        provider = MagicMock()
+        provider.get_token.return_value = "passport-token"
+        login_info = SimpleNamespace(
+            endpoint="https://bioos",
+            region="cn-north-1",
+            access_key="ak",
+            secret_key="sk",
+        )
+        client = RepositoryRestClient(
+            endpoint="https://repo.example/base",
+            passport_provider=provider,
+            sign_requests=True,
+            session=session,
+        )
+
+        with patch("bioos.internal.repository.Config.login_info", return_value=login_info):
+            result = client.get("/api/repository/data_set", params={"id": ["ds1", "ds2"], "page": 1})
+
+        self.assertEqual(result, {"ok": True})
+        _, url = session.request.call_args.args
+        headers = session.request.call_args.kwargs["headers"]
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query["id"], ["ds1", "ds2"])
+        self.assertEqual(query["page"], ["1"])
+        self.assertIn("X-Signature", query)
+        self.assertEqual(headers["Authorization"], "Bearer passport-token")
+
+    def test_repository_rest_client_download_url_writes_stream(self):
+        response = MagicMock()
+        response.iter_content.return_value = [b"ab", b"", b"cd"]
+        session = MagicMock()
+        session.request.return_value = response
+        client = RepositoryRestClient(
+            endpoint="https://repo.example",
+            passport_provider=MagicMock(),
+            sign_requests=False,
+            session=session,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "file.txt"
+            result = client.download_url(
+                "https://download.example/file",
+                str(target),
+                headers={"X-Test": "yes"},
+                chunk_size=2,
+            )
+            downloaded_text = Path(result["target"]).read_text(encoding="utf-8")
+
+        self.assertEqual(result["bytes_written"], 4)
+        self.assertEqual(downloaded_text, "abcd")
+        session.request.assert_called_once_with(
+            "GET",
+            "https://download.example/file",
+            headers={"X-Test": "yes"},
+            stream=True,
+            timeout=60,
+        )
+
+    def test_dataset_resource_list_maps_params_and_returns_dataframe(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        resource.repository_client.get.return_value = {"Items": [{"id": "ds1", "name": "dataset"}]}
+
+        result = resource.list(
+            ids=["ds1"],
+            order_by="createTime:desc",
+            search_word="rna",
+            project_data_type=["omics"],
+        )
+
+        self.assertEqual(result.to_dict(orient="records"), [{"id": "ds1", "name": "dataset"}])
+        resource.repository_client.get.assert_called_once_with(
+            "/api/repository/data_set",
+            params={
+                "orderBy": "createTime:desc",
+                "searchWord": "rna",
+                "id": ["ds1"],
+                "projectDataType": ["omics"],
+            },
+        )
+
+    def test_dataset_resource_raw_returns_payload(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        resource.repository_client.get.return_value = {"Items": [{"id": "ds1"}], "Total": 1}
+
+        result = resource.list(raw=True)
+
+        self.assertEqual(result, {"Items": [{"id": "ds1"}], "Total": 1})
+
+    def test_dataset_resource_get_uses_list_filter_and_returns_record(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        resource.repository_client.get.return_value = {
+            "items": [{"id": "ds1", "name": "dataset"}],
+            "total": 1,
+        }
+
+        result = resource.get("ds1")
+
+        self.assertEqual(result, {"id": "ds1", "name": "dataset"})
+        resource.repository_client.get.assert_called_once_with(
+            "/api/repository/data_set",
+            params={"id": ["ds1"], "displayLevel": "Full"},
+        )
+
+    def test_dataset_files_maps_params_and_requires_library(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        resource.repository_client.get.return_value = {"Items": [{"id": "file1"}]}
+        dataset = DataSet.__new__(DataSet)
+        dataset.data_set_id = "ds/1"
+        dataset.data_library_id = "lib1"
+        dataset.resource = resource
+
+        result = dataset.files(ids=["file1"], search_scope=["name"], file_type=["bam"])
+
+        self.assertEqual(result.to_dict(orient="records"), [{"id": "file1"}])
+        resource.repository_client.get.assert_called_once_with(
+            "/api/repository/data_set/ds%2F1/data_file",
+            params={
+                "dataLibraryID": "lib1",
+                "searchScope": ["name"],
+                "id": ["file1"],
+                "fileType": ["bam"],
+            },
+        )
+
+    def test_dataset_file_ids_maps_params_and_returns_ids(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        resource.repository_client.get.return_value = {"ids": ["file1", "file2"]}
+        dataset = DataSet.__new__(DataSet)
+        dataset.data_set_id = "ds1"
+        dataset.data_library_id = "lib1"
+        dataset.resource = resource
+
+        result = dataset.file_ids(search_scope=["name"], file_type=["fastq"])
+
+        self.assertEqual(result, ["file1", "file2"])
+        resource.repository_client.get.assert_called_once_with(
+            "/api/repository/data_set/ds1/data_file/ids",
+            params={
+                "dataLibraryID": "lib1",
+                "searchScope": ["name"],
+                "fileType": ["fastq"],
+            },
+        )
+
+    def test_dataset_drs_object_uses_drs_client(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.drs_client = MagicMock()
+        resource.drs_client.get.return_value = {"id": "object-1"}
+
+        result = resource.drs_object("object/1")
+
+        self.assertEqual(result, {"id": "object-1"})
+        resource.drs_client.get.assert_called_once_with("/ga4gh/drs/v1/objects/object%2F1")
+
+    def test_dataset_drs_access_uses_access_endpoint(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.drs_client = MagicMock()
+        resource.drs_client.get.side_effect = [
+            {"id": "object-1", "access_methods": [{"type": "https", "access_id": "https"}]},
+            {"url": "https://download"},
+        ]
+
+        result = resource.drs_access("drs://imc-drs.miracle.ac.cn/object/1", access_id="https")
+
+        self.assertEqual(result, {"url": "https://download"})
+        self.assertEqual(resource.drs_client.get.call_count, 2)
+        resource.drs_client.get.assert_any_call("/ga4gh/drs/v1/objects/object%2F1")
+        resource.drs_client.get.assert_any_call(
+            "/ga4gh/drs/v1/objects/object%2F1/access/https"
+        )
+
+    def test_dataset_drs_access_uses_object_access_methods_first(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.drs_client = MagicMock()
+        resource.drs_client.get.return_value = {
+            "id": "object-1",
+            "access_methods": [
+                {"type": "https", "access_id": "https", "access_url": {"url": "https://download"}},
+                {"type": "tos", "access_id": "tos", "access_url": {"url": "s3://bucket/key"}},
+            ],
+        }
+
+        result = resource.drs_access("object-1", access_id="https")
+
+        self.assertEqual(result, {"url": "https://download"})
+        resource.drs_client.get.assert_called_once_with("/ga4gh/drs/v1/objects/object-1")
+
+    def test_dataset_download_drs_object_gets_access_url_and_writes_file(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.drs_client = MagicMock()
+        resource.drs_client.get.return_value = {
+            "name": "object.txt",
+            "access_methods": [
+                {"type": "https", "access_id": "https", "access_url": {"url": "https://download", "headers": ["X-Test: yes"]}},
+            ],
+        }
+        resource.drs_client.download_url.return_value = {
+            "target": "/tmp/object.txt",
+            "bytes_written": 4,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = resource.download_drs_object("object-1", target=tmpdir)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["object_id"], "object-1")
+        resource.drs_client.download_url.assert_called_once()
+        self.assertEqual(resource.drs_client.download_url.call_args.args[0], "https://download")
+        self.assertEqual(resource.drs_client.download_url.call_args.kwargs["headers"], {"X-Test": "yes"})
+
+    def test_dataset_download_files_uses_file_records_and_drs_download(self):
+        resource = DataSetResource.__new__(DataSetResource)
+        resource.repository_client = MagicMock()
+        record = {"id": "file1", "name": "reads.fastq.gz", "drsURL": "drs://imc-drs.miracle.ac.cn/file1"}
+        resource.repository_client.get.return_value = {"items": [record]}
+        resource.download_drs_object = MagicMock(
+            return_value={
+                "success": True,
+                "object_id": "file1",
+                "target": "/tmp/reads.fastq.gz",
+            }
+        )
+        dataset = DataSet.__new__(DataSet)
+        dataset.data_set_id = "ds1"
+        dataset.data_library_id = "lib1"
+        dataset.resource = resource
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = dataset.download_files(target=tmpdir)
+            expected_target = str(Path(tmpdir) / "reads.fastq.gz")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["downloaded_count"], 1)
+        resource.download_drs_object.assert_called_once_with(
+            "file1",
+            target=expected_target,
+            access_id="https",
+            overwrite=False,
+            object_info=record,
+            object_name="reads.fastq.gz",
+        )
+
+    def test_network_resource_exposes_dataset_and_drs_helpers(self):
+        network = NetworkResource.__new__(NetworkResource)
+        network.repository_endpoint = "https://network.miracle.ac.cn"
+        network.drs_endpoint = "http://imc-drs.miracle.ac.cn"
+        network.passport_provider = MagicMock()
+
+        with patch("bioos.resource.network.DataSetResource") as resource_factory:
+            data_sets = network.datasets
+            data_set = network.dataset("ds1", data_library_id="lib1")
+            drs_result = network.drs_object("object-1")
+            access_result = network.drs_access("object-1", access_id="https")
+            download_result = network.download_drs_object("object-1", target="/tmp/object.txt", overwrite=True)
+
+        self.assertEqual(data_sets, resource_factory.return_value)
+        resource_factory.assert_called_with(
+            repository_endpoint="https://network.miracle.ac.cn",
+            drs_endpoint="http://imc-drs.miracle.ac.cn",
+            passport_provider=network.passport_provider,
+        )
+        resource_factory.return_value.data_set.assert_called_once_with("ds1", data_library_id="lib1")
+        resource_factory.return_value.drs_object.assert_called_once_with("object-1")
+        resource_factory.return_value.drs_access.assert_called_once_with("object-1", access_id="https")
+        resource_factory.return_value.download_drs_object.assert_called_once_with(
+            "object-1",
+            target="/tmp/object.txt",
+            access_id="https",
+            overwrite=True,
+        )
+        self.assertEqual(data_set, resource_factory.return_value.data_set.return_value)
+        self.assertEqual(drs_result, resource_factory.return_value.drs_object.return_value)
+        self.assertEqual(access_result, resource_factory.return_value.drs_access.return_value)
+        self.assertEqual(download_result, resource_factory.return_value.download_drs_object.return_value)
 
     def test_usage_resource_rejects_invalid_asset_type(self):
         usage = UsageResource.__new__(UsageResource)


### PR DESCRIPTION
## Summary

This PR adds BioOS Network support to `pybioos`, including dataset discovery, dataset file queries, GA4GH DRS object resolution, DRS access URL retrieval, and file download commands.

The implementation keeps the existing BioOS AK/SK authentication model. Network access is handled internally by exchanging BioOS AK/SK credentials for an AAAI passport through `GetRepositoryPassport`, then using that passport for Repository and DRS REST APIs.

## Key Changes

- Add `bioos.network()` SDK entrypoint
- Add Network dataset resource APIs:
  - `bioos.network().datasets.list(...)`
  - `bioos.network().dataset(data_set_id, data_library_id).get(...)`
  - `bioos.network().dataset(data_set_id, data_library_id).files(...)`
  - `bioos.network().dataset(data_set_id, data_library_id).file_ids(...)`
  - `bioos.network().dataset(data_set_id, data_library_id).download_files(...)`
- Add DRS APIs:
  - `bioos.network().drs_object(object_id)`
  - `bioos.network().drs_access(object_id, access_id="https")`
  - `bioos.network().download_drs_object(object_id, ...)`
- Add CLI commands:
  - `bioos network dataset list`
  - `bioos network dataset get`
  - `bioos network dataset files`
  - `bioos network dataset file-ids`
  - `bioos network dataset download-files`
  - `bioos network dataset drs`
  - `bioos network drs`
  - `bioos network drs access`
  - `bioos network drs download`
- Add Network endpoint config support:
  - `repository_endpoint`
  - `drs_endpoint`
  - `BIOOS_REPOSITORY_ENDPOINT`
  - `BIOOS_DRS_ENDPOINT`
- Add internal Repository/DRS REST client with:
  - AAAI passport provider and cache
  - Repository request signing
  - DRS bearer-token requests
  - repeated query parameter encoding
  - streaming downloads
- Bump package version to `0.0.24`

## Auth Design

Existing BioOS platform APIs continue to use:

```text
AK/SK -> Volc V4 signed RPC -> BioOS RPC gateway
