### PR TITLE
feat: add workspace delete sdk

### DIFF
--- a/bioos/resource/workspaces.py
+++ b/bioos/resource/workspaces.py
@@ -151,6 +151,28 @@ class Workspace(metaclass=SingletonType):
         params = {"ClusterID": cluster_id, "Type": type_, "ID": self._id}
         return Config.service().bind_cluster_to_workspace(params)
 
+    def delete(self) -> dict:
+        """Deletes this workspace by workspace ID or unique workspace name."""
+        params = {"ID": self._resolve_workspace_id_for_delete()}
+        return Config.service().delete_workspace(params)
+
+    def _resolve_workspace_id_for_delete(self) -> str:
+        workspace_infos = Config.service().list_workspaces({
+            "Filter": {
+                "IDs": [self._id]
+            }
+        }).get("Items", [])
+        if len(workspace_infos) == 1:
+            return str(workspace_infos[0].get("ID") or self._id)
+
+        workspace_infos = Config.service().list_workspaces({"PageSize": 0}).get("Items", [])
+        matched = [info for info in workspace_infos if info.get("Name") == self._id]
+        if len(matched) == 1:
+            return str(matched[0].get("ID"))
+        if len(matched) > 1:
+            raise ValueError(f"Multiple workspaces found with name '{self._id}'. Delete by workspace ID instead.")
+        raise ValueError(f"Workspace not found by ID or name: {self._id}")
+
     def list_members(self,
                      filter_: dict = None,
                      page_number: int = None,

--- a/bioos/service/BioOsService.py
+++ b/bioos/service/BioOsService.py
@@ -52,6 +52,11 @@ class BioOsService(Service):
                 'Action': 'CreateWorkspace',
                 'Version': '2021-03-04'
             }, {}, {}),
+            'DeleteWorkspace':
+            ApiInfo('POST', '/', {
+                'Action': 'DeleteWorkspace',
+                'Version': '2021-03-04'
+            }, {}, {}),
             'AddMembers':
             ApiInfo('POST', '/', {
                 'Action': 'AddMembers',
@@ -265,6 +270,9 @@ class BioOsService(Service):
 
     def create_workspace(self, params):
         return self.__request('CreateWorkspace', params)
+
+    def delete_workspace(self, params):
+        return self.__request('DeleteWorkspace', params)
 
     def add_members(self, params):
         return self.__request('AddMembers', params)

--- a/tests/test_ops_unit.py
+++ b/tests/test_ops_unit.py
@@ -301,6 +301,17 @@ class TestOpsHelpers(unittest.TestCase):
         self.assertEqual(result, {"DataSetID": "ds1"})
         request_mock.assert_called_once_with("SearchDRS", params)
 
+    def test_bioos_service_registers_delete_workspace(self):
+        service = BioOsService.__new__(BioOsService)
+        params = {"ID": "wid"}
+
+        self.assertIn("DeleteWorkspace", BioOsService.get_api_info())
+        with patch.object(BioOsService, "_BioOsService__request", return_value={}) as request_mock:
+            result = service.delete_workspace(params)
+
+        self.assertEqual(result, {})
+        request_mock.assert_called_once_with("DeleteWorkspace", params)
+
     def test_repository_passport_provider_requires_token(self):
         service = MagicMock()
         service.get_repository_passport.return_value = {"ExpiresIn": 3600}
@@ -937,6 +948,70 @@ class TestOpsHelpers(unittest.TestCase):
                 },
             }
         )
+
+    def test_workspace_delete_calls_service(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "wid"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_workspaces.return_value = {"Items": [{"ID": "wid"}]}
+            service_mock.return_value.delete_workspace.return_value = {}
+            result = workspace.delete()
+
+        self.assertEqual(result, {})
+        service_mock.return_value.list_workspaces.assert_called_once_with(
+            {"Filter": {"IDs": ["wid"]}}
+        )
+        service_mock.return_value.delete_workspace.assert_called_once_with({"ID": "wid"})
+
+    def test_workspace_delete_resolves_workspace_name(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "test1"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_workspaces.side_effect = [
+                {"Items": []},
+                {"Items": [{"ID": "wid", "Name": "test1"}, {"ID": "other", "Name": "other"}]},
+            ]
+            service_mock.return_value.delete_workspace.return_value = {}
+            result = workspace.delete()
+
+        self.assertEqual(result, {})
+        service_mock.return_value.list_workspaces.assert_has_calls(
+            [
+                unittest.mock.call({"Filter": {"IDs": ["test1"]}}),
+                unittest.mock.call({"PageSize": 0}),
+            ]
+        )
+        service_mock.return_value.delete_workspace.assert_called_once_with({"ID": "wid"})
+
+    def test_workspace_delete_rejects_duplicate_workspace_name(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "test1"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_workspaces.side_effect = [
+                {"Items": []},
+                {"Items": [{"ID": "wid1", "Name": "test1"}, {"ID": "wid2", "Name": "test1"}]},
+            ]
+            with self.assertRaisesRegex(ValueError, "Multiple workspaces"):
+                workspace.delete()
+
+        service_mock.return_value.delete_workspace.assert_not_called()
+
+    def test_workspace_delete_rejects_missing_workspace(self):
+        workspace = Workspace.__new__(Workspace)
+        workspace._id = "missing"
+
+        with patch("bioos.resource.workspaces.Config.service") as service_mock:
+            service_mock.return_value.list_workspaces.side_effect = [
+                {"Items": []},
+                {"Items": []},
+            ]
+            with self.assertRaisesRegex(ValueError, "Workspace not found"):
+                workspace.delete()
+
+        service_mock.return_value.delete_workspace.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds SDK support for deleting a BioOS workspace through the existing workspace resource object.

The new API is intentionally SDK-only. No CLI command is added.

## Changes

- Register the BioOS RPC action `DeleteWorkspace`.
- Add `BioOsService.delete_workspace(...)`.
- Add `Workspace.delete()` under the existing SDK resource path.
- Support deleting by either workspace ID or a unique workspace name.
- Add unit tests for:
  - `DeleteWorkspace` service registration and dispatch
  - deleting by workspace ID
  - resolving and deleting by workspace name
  - rejecting duplicate workspace names
  - rejecting missing workspaces