### PR TITLE
feat(cli): support directory upload and run metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,16 @@ List workspace files:
 bioos file list --workspace-name my-workspace --recursive
 ```
 
-Upload local files to a workspace:
+Upload local files or directories to a workspace:
 
 ```bash
 bioos file upload \
   --workspace-name my-workspace \
   --source ./inputs/sample1.fastq.gz \
   --source ./inputs/sample2.fastq.gz \
+  --source ./references \
   --target input_provision/ \
+  --no-flatten \
   --skip-existing
 ```
 
@@ -370,11 +372,12 @@ Current usage commands:
 
 ### Upload
 
-`bioos file upload` uploads one or more local files into the current workspace bucket.
+`bioos file upload` uploads one or more local files or directories into the current workspace bucket.
 
 Key capabilities:
 
 - multiple `--source` inputs in one command
+- recursive directory upload
 - multipart upload for large files
 - resumable uploads with checkpoint files
 - per-file retry controls
@@ -386,8 +389,9 @@ Example:
 ```bash
 bioos file upload \
   --workspace-name my-workspace \
-  --source ./data/sample.bam \
+  --source ./data \
   --target input_provision/ \
+  --no-flatten \
   --checkpoint-dir ~/.bioos/upload-checkpoints \
   --max-retries 3 \
   --task-num 10
@@ -396,13 +400,17 @@ bioos file upload \
 Available upload options:
 
 - `--workspace-name`: target workspace name
-- `--source`: local file path, can be repeated
+- `--source`: local file or directory path, can be repeated
 - `--target`: target prefix in the workspace bucket
 - `--flatten/--no-flatten`: control whether local directory structure is preserved
 - `--skip-existing`: skip upload when the target key already exists
 - `--checkpoint-dir`: checkpoint directory for resumable multipart uploads
 - `--max-retries`: retry count per file after the first attempt
 - `--task-num`: multipart parallel task count
+
+When uploading directories, `--no-flatten` preserves the uploaded directory tree under
+the target prefix. `--flatten` uploads every file to the target prefix by basename and
+fails fast if multiple local files would map to the same target key.
 
 ### Download
 
@@ -505,7 +513,7 @@ Notes:
 
 ## Current Limitations
 
-- directory upload is not supported yet; `bioos file upload` currently accepts files, not whole directories
+- uploading empty directories creates no objects because workspace storage is object-based
 - `bioos file download` does not yet support direct signed `https://...` download URLs
 - usage commands depend on backend permissions; owner-only APIs require the main account AK/SK
 

--- a/bioos/cli/common.py
+++ b/bioos/cli/common.py
@@ -3,7 +3,7 @@ import json
 import sys
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 def _json_default(value: Any) -> Any:
@@ -82,6 +82,7 @@ def add_bool_argument(
     name: str,
     default: bool,
     help_text: str,
+    negative_help_text: Optional[str] = None,
 ) -> None:
     cli_name = f"--{name.replace('_', '-')}"
     legacy_name = f"--{name}"
@@ -105,7 +106,7 @@ def add_bool_argument(
             *negative_option_names,
             dest=name,
             action="store_false",
-            help=f"Disable: {help_text}",
+            help=negative_help_text or f"Disable: {help_text}",
         )
 
 

--- a/bioos/cli/list_ies_apps.py
+++ b/bioos/cli/list_ies_apps.py
@@ -1,0 +1,27 @@
+import sys
+
+from bioos.cli.common import add_argument, build_parser, run_cli
+from bioos.ops.auth import workspace_context_from_args
+from bioos.ops.formatters import dataframe_records
+
+
+def build_args():
+    parser = build_parser("List IES application instances in a Bio-OS workspace.")
+    add_argument(parser, "workspace_name", required=True, help="Workspace name.")
+    return parser
+
+
+def handle(args):
+    _, ws = workspace_context_from_args(args)
+    ies_df = ws.webinstanceapps.list()
+    return dataframe_records(ies_df)
+
+
+def main():
+    parser = build_args()
+    args = parser.parse_args()
+    sys.exit(run_cli(handle, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/bioos/cli/main.py
+++ b/bioos/cli/main.py
@@ -22,9 +22,11 @@ from bioos.cli import (
     get_workspace_profile,
     list_bioos_workspaces,
     list_files_from_workspace,
+    list_ies_apps,
     list_workspace_members,
     list_submissions_from_workspace,
     list_workflows_from_workspace,
+    run as run_commands,
     search_dockstore,
     upload_dashboard_file,
     upload_files_to_workspace,
@@ -48,6 +50,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_workspace_group(subparsers)
     _add_workflow_group(subparsers)
     _add_submission_group(subparsers)
+    _add_run_group(subparsers)
     _add_file_group(subparsers)
     _add_usage_group(subparsers)
     _add_ies_group(subparsers)
@@ -414,6 +417,59 @@ def _add_submission_group(subparsers: Any) -> None:
     logs_parser.set_defaults(handler=get_submission_logs.handle)
 
 
+def _add_run_group(subparsers: Any) -> None:
+    run_parser = subparsers.add_parser("run", help="Workflow run commands.")
+    run_subparsers = run_parser.add_subparsers(dest="run_command")
+    run_parser.set_defaults(_parser=run_parser)
+
+    list_parser = run_subparsers.add_parser("list", help="List runs under a submission.")
+    add_auth_arguments(list_parser)
+    add_output_arguments(list_parser)
+    add_argument(list_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(list_parser, "submission_id", required=True, help="Submission ID.")
+    add_argument(list_parser, "page_number", required=False, type=int, default=1, help="Page number.")
+    add_argument(list_parser, "page_size", required=False, type=int, default=10, help="Page size. Use 0 for all.")
+    add_argument(list_parser, "keyword", required=False, default=None, help="Optional run keyword filter.")
+    add_argument(
+        list_parser,
+        "run_id",
+        required=False,
+        action="append",
+        help="Optional run ID filter. Can be specified multiple times.",
+    )
+    add_argument(
+        list_parser,
+        "status",
+        required=False,
+        action="append",
+        help="Optional run status filter. Can be specified multiple times.",
+    )
+    list_parser.set_defaults(_parser=list_parser)
+    list_parser.set_defaults(handler=run_commands.handle_list)
+
+    tasks_parser = run_subparsers.add_parser("tasks", help="List tasks under a run.")
+    add_auth_arguments(tasks_parser)
+    add_output_arguments(tasks_parser)
+    add_argument(tasks_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(tasks_parser, "run_id", required=True, help="Run ID.")
+    add_argument(tasks_parser, "page_number", required=False, type=int, default=1, help="Page number.")
+    add_argument(tasks_parser, "page_size", required=False, type=int, default=10, help="Page size. Use 0 for all.")
+    tasks_parser.set_defaults(_parser=tasks_parser)
+    tasks_parser.set_defaults(handler=run_commands.handle_tasks)
+
+    metric_data_parser = run_subparsers.add_parser("metric-data", help="Get task metric data under a run.")
+    add_auth_arguments(metric_data_parser)
+    add_output_arguments(metric_data_parser)
+    add_argument(metric_data_parser, "workspace_name", required=True, help="Workspace name.")
+    add_argument(metric_data_parser, "run_id", required=True, help="Run ID.")
+    add_argument(metric_data_parser, "task_name", required=True, help="Task name.")
+    add_argument(metric_data_parser, "period", required=True, help="Metric interval granularity.")
+    add_argument(metric_data_parser, "start_time", required=True, type=int, help="Start timestamp.")
+    add_argument(metric_data_parser, "end_time", required=True, type=int, help="End timestamp.")
+    metric_data_parser.set_defaults(_parser=metric_data_parser)
+    metric_data_parser.set_defaults(handler=run_commands.handle_metric_data)
+
+
 def _add_file_group(subparsers: Any) -> None:
     file_parser = subparsers.add_parser("file", help="Workspace file commands.")
     file_subparsers = file_parser.add_subparsers(dest="file_command")
@@ -428,10 +484,25 @@ def _add_file_group(subparsers: Any) -> None:
         "source",
         required=True,
         action="append",
-        help="Local file path. Can be specified multiple times.",
+        help=(
+            "Local file or directory path. Repeat this option to upload multiple "
+            "files or directories."
+        ),
     )
     add_argument(upload_parser, "target", required=False, default="", help="Target prefix path in the workspace bucket.")
-    add_bool_argument(upload_parser, "flatten", default=True, help_text="Flatten local paths during upload.")
+    add_bool_argument(
+        upload_parser,
+        "flatten",
+        default=True,
+        help_text=(
+            "Flatten uploaded paths. For directory upload, the default --flatten "
+            "uploads files by basename under target; use --no-flatten to preserve "
+            "the directory tree under target."
+        ),
+        negative_help_text=(
+            "Preserve directory tree under target when uploading directories."
+        ),
+    )
     add_bool_argument(
         upload_parser,
         "skip_existing",
@@ -537,6 +608,13 @@ def _add_ies_group(subparsers: Any) -> None:
     add_bool_argument(create_parser, "ies_auto_start", default=True, help_text="Auto-start the instance.")
     create_parser.set_defaults(_parser=create_parser)
     create_parser.set_defaults(handler=create_iesapp.handle)
+
+    list_parser = ies_subparsers.add_parser("list", help="List IES application instances.")
+    add_auth_arguments(list_parser)
+    add_output_arguments(list_parser)
+    add_argument(list_parser, "workspace_name", required=True, help="Workspace name.")
+    list_parser.set_defaults(_parser=list_parser)
+    list_parser.set_defaults(handler=list_ies_apps.handle)
 
     status_parser = ies_subparsers.add_parser("status", help="Check IES instance status.")
     add_auth_arguments(status_parser)

--- a/bioos/cli/run.py
+++ b/bioos/cli/run.py
@@ -1,0 +1,52 @@
+from bioos.ops.auth import login_with_args, resolve_workspace
+from bioos.resource.workflows import Run
+
+
+def handle_list(args):
+    workspace_id = _login_and_resolve_workspace(args)
+    return Run.list_runs(
+        workspace_id=workspace_id,
+        submission_id=args.submission_id,
+        page_number=args.page_number,
+        page_size=args.page_size,
+        filter_=_build_list_filter(args),
+    )
+
+
+def handle_tasks(args):
+    workspace_id = _login_and_resolve_workspace(args)
+    return Run.list_tasks(
+        workspace_id=workspace_id,
+        run_id=args.run_id,
+        page_number=args.page_number,
+        page_size=args.page_size,
+    )
+
+
+def handle_metric_data(args):
+    workspace_id = _login_and_resolve_workspace(args)
+    return Run.get_task_metric_data_for_run(
+        workspace_id=workspace_id,
+        run_id=args.run_id,
+        name=args.task_name,
+        period=args.period,
+        start_time=args.start_time,
+        end_time=args.end_time,
+    )
+
+
+def _login_and_resolve_workspace(args) -> str:
+    login_with_args(args)
+    workspace_id, _ = resolve_workspace(args.workspace_name)
+    return workspace_id
+
+
+def _build_list_filter(args):
+    filter_ = {}
+    if args.keyword:
+        filter_["Keyword"] = args.keyword
+    if args.run_id:
+        filter_["IDs"] = args.run_id
+    if args.status:
+        filter_["Status"] = args.status
+    return filter_ or None

--- a/bioos/cli/upload_files_to_workspace.py
+++ b/bioos/cli/upload_files_to_workspace.py
@@ -12,10 +12,25 @@ def build_args():
         "source",
         required=True,
         action="append",
-        help="Local file path. Can be specified multiple times.",
+        help=(
+            "Local file or directory path. Repeat this option to upload multiple "
+            "files or directories."
+        ),
     )
     add_argument(parser, "target", required=False, default="", help="Target prefix path in the workspace bucket.")
-    add_bool_argument(parser, "flatten", default=True, help_text="Flatten local paths during upload.")
+    add_bool_argument(
+        parser,
+        "flatten",
+        default=True,
+        help_text=(
+            "Flatten uploaded paths. For directory upload, the default --flatten "
+            "uploads files by basename under target; use --no-flatten to preserve "
+            "the directory tree under target."
+        ),
+        negative_help_text=(
+            "Preserve directory tree under target when uploading directories."
+        ),
+    )
     add_bool_argument(parser, "skip_existing", default=False, help_text="Skip files whose target object already exists.")
     add_argument(
         parser,

--- a/bioos/internal/tos.py
+++ b/bioos/internal/tos.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 import os
 import re
-from typing import List
+from typing import Dict, List
 
 import tos
 from tos import DataTransferType, HttpMethodType
@@ -93,6 +93,90 @@ class TOSHandler:
             to_upload_path = to_upload_path.lstrip("/")
 
         return os.path.normpath(os.path.join(target_path, to_upload_path))
+
+    def _passes_file_filter(self,
+                            file_path: str,
+                            include: str = "",
+                            ignore: str = "") -> bool:
+        basename = os.path.basename(os.path.normpath(file_path))
+        if include != "":
+            return re.fullmatch(include, basename) is not None and not (
+                ignore != "" and re.fullmatch(ignore, basename))
+        return not (ignore != "" and re.fullmatch(ignore, basename))
+
+    def _iter_directory_upload_files(self, directory_path: str) -> List[str]:
+        files_to_upload = []
+        for root, dirs, filenames in os.walk(directory_path):
+            dirs[:] = sorted(dirs)
+            for filename in sorted(filenames):
+                file_path = os.path.normpath(os.path.join(root, filename))
+                if os.path.isfile(file_path):
+                    files_to_upload.append(file_path)
+        return files_to_upload
+
+    def _directory_upload_key_source(self,
+                                     directory_path: str,
+                                     file_path: str,
+                                     flatten: bool) -> str:
+        if flatten:
+            return file_path
+
+        relative_file_path = os.path.relpath(file_path, directory_path)
+        if os.path.isabs(directory_path):
+            directory_prefix = os.path.basename(directory_path)
+        else:
+            directory_prefix = directory_path
+        return os.path.normpath(os.path.join(directory_prefix,
+                                             relative_file_path))
+
+    def build_upload_plan(
+        self,
+        files_to_upload: List[str],
+        target_path: str,
+        flatten: bool,
+        ignore: str = "",
+        include: str = "",
+    ) -> List[Dict[str, object]]:
+        upload_plan = []
+        normalized_sources = [
+            os.path.normpath(os.path.expanduser(str(file_path)))
+            for file_path in files_to_upload
+        ]
+
+        for source in normalized_sources:
+            if os.path.isdir(source):
+                for file_path in self._iter_directory_upload_files(source):
+                    if not self._passes_file_filter(file_path, include, ignore):
+                        continue
+                    key_source = self._directory_upload_key_source(
+                        source, file_path, flatten)
+                    upload_plan.append({
+                        "source": file_path,
+                        "key": self._resolve_upload_key(key_source, target_path, flatten),
+                        "from_directory": True,
+                    })
+                continue
+
+            if not self._passes_file_filter(source, include, ignore):
+                continue
+            upload_plan.append({
+                "source": source,
+                "key": self._resolve_upload_key(source, target_path, flatten),
+                "from_directory": False,
+            })
+
+        return upload_plan
+
+    def upload_key_conflicts(self,
+                             upload_plan: List[Dict[str, object]]) -> Dict[str, List[str]]:
+        key_sources = {}
+        for item in upload_plan:
+            key_sources.setdefault(str(item["key"]), []).append(str(item["source"]))
+        return {
+            key: sources
+            for key, sources in key_sources.items()
+            if len(sources) > 1
+        }
 
     def _build_upload_checkpoint_file(self,
                                       file_path: str,
@@ -205,13 +289,9 @@ class TOSHandler:
                 cur_marker = resp.next_marker
         return object_list
 
-    def upload_objects(
+    def upload_planned_objects(
         self,
-        files_to_upload: List[str],
-        target_path: str,
-        flatten: bool,
-        ignore: str = "",
-        include: str = "",
+        upload_plan: List[Dict[str, object]],
         checkpoint_dir: str = "",
         max_retries: int = 3,
         task_num: int = DEFAULT_THREAD,
@@ -220,22 +300,21 @@ class TOSHandler:
         def _upload_fail(error_list_: List[str], file_path_: str):
             error_list_.append(file_path_)
 
-        files_to_upload = self.files_filter(files_to_upload, include, ignore)
         max_retries = max(int(max_retries) if max_retries is not None else 3, 0)
         task_num = max(int(task_num) if task_num is not None else DEFAULT_THREAD, 1)
-        if len(files_to_upload) == 0:
+        if len(upload_plan) == 0:
             self._info_logging("no files to upload")
             return []
 
         error_list = []
-        for file_path in files_to_upload:
+        for item in upload_plan:
+            file_path = str(item["source"])
+            tos_target_path = str(item["key"])
             if not os.path.isfile(file_path):
                 error_list.append(file_path)
                 self._error_logging(f"'{file_path}' is not a file")
                 continue
             fsize = os.path.getsize(file_path)
-            tos_target_path = self._resolve_upload_key(file_path, target_path,
-                                                       flatten)
 
             self._info_logging(
                 f"[{file_path}] begins to upload to [{tos_target_path}]")
@@ -265,6 +344,31 @@ class TOSHandler:
                 f"\n{error_list}")
 
         return error_list
+
+    def upload_objects(
+        self,
+        files_to_upload: List[str],
+        target_path: str,
+        flatten: bool,
+        ignore: str = "",
+        include: str = "",
+        checkpoint_dir: str = "",
+        max_retries: int = 3,
+        task_num: int = DEFAULT_THREAD,
+    ) -> List[str]:
+        upload_plan = self.build_upload_plan(
+            files_to_upload=files_to_upload,
+            target_path=target_path,
+            flatten=flatten,
+            ignore=ignore,
+            include=include,
+        )
+        return self.upload_planned_objects(
+            upload_plan=upload_plan,
+            checkpoint_dir=checkpoint_dir,
+            max_retries=max_retries,
+            task_num=task_num,
+        )
 
     def download_objects(self,
                          files_to_download: List[str],
@@ -369,14 +473,8 @@ class TOSHandler:
         for f in files:
             if f.endswith("/"):
                 raise ParameterError("tos files path")
-            basename = os.path.basename(os.path.normpath(f))
-            if include != "":
-                if not re.fullmatch(include, basename) or (
-                        ignore != "" and re.fullmatch(ignore, basename)):
-                    continue
-            else:
-                if ignore != "" and re.fullmatch(ignore, basename):
-                    continue
+            if not self._passes_file_filter(f, include, ignore):
+                continue
 
             file_lst.append(f)
         return file_lst

--- a/bioos/ops/formatters.py
+++ b/bioos/ops/formatters.py
@@ -5,7 +5,29 @@ from typing import Any, Dict, List, Optional
 def dataframe_records(df: Any) -> List[Dict[str, Any]]:
     if df is None or getattr(df, "empty", True):
         return []
-    return df.to_dict(orient="records")
+    return [
+        {key: _clean_missing_values(value) for key, value in record.items()}
+        for record in df.to_dict(orient="records")
+    ]
+
+
+def _clean_missing_values(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _clean_missing_values(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_clean_missing_values(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clean_missing_values(item) for item in value)
+    if value is None:
+        return None
+    try:
+        import pandas as pd
+        return None if bool(pd.isna(value)) else value
+    except (ImportError, TypeError, ValueError):
+        return value
 
 
 def to_iso(value: Any) -> Optional[str]:
@@ -27,4 +49,3 @@ def to_iso(value: Any) -> Optional[str]:
             timestamp /= 1000.0
         return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return str(value)
-

--- a/bioos/ops/workspace_files.py
+++ b/bioos/ops/workspace_files.py
@@ -25,20 +25,6 @@ def _normalize_local_sources(sources: Union[str, Iterable[str]]) -> List[str]:
     return normalized_sources
 
 
-def _resolve_workspace_upload_key(local_file_path: str,
-                                  target: str,
-                                  flatten: bool) -> str:
-    if flatten:
-        to_upload_path = os.path.basename(local_file_path)
-    else:
-        to_upload_path = os.path.normpath(local_file_path)
-
-    if os.path.isabs(to_upload_path):
-        to_upload_path = to_upload_path.lstrip("/")
-
-    return os.path.normpath(os.path.join(target, to_upload_path))
-
-
 def _upload_local_files_with_workspace(
     ws,
     workspace_id: str,
@@ -58,18 +44,27 @@ def _upload_local_files_with_workspace(
     if missing_files:
         raise FileNotFoundError(f"Local file not found: {missing_files[0]}")
 
-    directory_sources = [source for source in normalized_sources if os.path.isdir(source)]
-    if directory_sources:
-        raise IsADirectoryError(f"Directory upload is not supported yet: {directory_sources[0]}")
-
     resolved_checkpoint_dir = os.path.abspath(
         os.path.expanduser(checkpoint_dir or DEFAULT_UPLOAD_CHECKPOINT_DIR))
 
+    raw_upload_plan = ws.files.tos_handler.build_upload_plan(
+        files_to_upload=normalized_sources,
+        target_path=target,
+        flatten=flatten,
+    )
+    if any(item["from_directory"] for item in raw_upload_plan):
+        conflicts = ws.files.tos_handler.upload_key_conflicts(raw_upload_plan)
+        if conflicts:
+            key = sorted(conflicts.keys())[0]
+            sources = ", ".join(conflicts[key])
+            raise ValueError(
+                f"Multiple local files map to target key '{key}': {sources}")
+
     upload_plan = []
-    for source in normalized_sources:
-        key = _resolve_workspace_upload_key(source, target, flatten)
+    for item in raw_upload_plan:
+        key = item["key"]
         upload_plan.append({
-            "source": source,
+            "source": item["source"],
             "key": key,
             "s3_url": ws.files.s3_urls([key])[0],
         })
@@ -84,10 +79,8 @@ def _upload_local_files_with_workspace(
 
     failed_sources = []
     if pending_uploads:
-        failed_sources = ws.files.tos_handler.upload_objects(
-            files_to_upload=[item["source"] for item in pending_uploads],
-            target_path=target,
-            flatten=flatten,
+        failed_sources = ws.files.tos_handler.upload_planned_objects(
+            upload_plan=pending_uploads,
             checkpoint_dir=resolved_checkpoint_dir,
             max_retries=max_retries,
             task_num=task_num,

--- a/bioos/resource/files.py
+++ b/bioos/resource/files.py
@@ -288,11 +288,22 @@ class FileResource(metaclass=SingletonType):
         if isinstance(sources, str):
             sources = [sources]
 
+        upload_plan = self.tos_handler.build_upload_plan(
+            files_to_upload=sources,
+            target_path=target,
+            flatten=flatten,
+        )
+        if any(item["from_directory"] for item in upload_plan):
+            conflicts = self.tos_handler.upload_key_conflicts(upload_plan)
+            if conflicts:
+                key = sorted(conflicts.keys())[0]
+                sources = ", ".join(conflicts[key])
+                raise ValueError(
+                    f"Multiple local files map to target key '{key}': {sources}")
+
         return len(
-            self.tos_handler.upload_objects(
-                sources,
-                target,
-                flatten,
+            self.tos_handler.upload_planned_objects(
+                upload_plan=upload_plan,
                 checkpoint_dir=checkpoint_dir,
                 max_retries=max_retries,
                 task_num=task_num if task_num is not None else 10,

--- a/bioos/resource/workflows.py
+++ b/bioos/resource/workflows.py
@@ -95,6 +95,68 @@ class Run(metaclass=SingletonType):  # 单例模式，why
         self._tasks: pd.DataFrame = None
         self.sync()  # 这里会初始化上方的UNKNOWN
 
+    @staticmethod
+    def list_runs(workspace_id: str,
+                  submission_id: str,
+                  page_number: Optional[int] = None,
+                  page_size: Optional[int] = None,
+                  filter_: Optional[dict] = None,
+                  top: Optional[dict] = None) -> dict:
+        """Lists runs under a submission."""
+        params = {
+            "SubmissionID": Run._normalize_required_string(submission_id, "submission_id"),
+            "WorkspaceID": Run._normalize_required_string(workspace_id, "workspace_id"),
+        }
+        if page_number is not None:
+            params["PageNumber"] = int(page_number)
+        if page_size is not None:
+            params["PageSize"] = int(page_size)
+        if filter_:
+            params["Filter"] = filter_
+        if top is not None:
+            params["Top"] = top
+        return Config.service().list_runs(params)
+
+    @staticmethod
+    def list_tasks(workspace_id: str,
+                   run_id: str,
+                   page_number: Optional[int] = None,
+                   page_size: Optional[int] = None,
+                   top: Optional[dict] = None) -> dict:
+        """Lists tasks under a run."""
+        params = {
+            "RunID": Run._normalize_required_string(run_id, "run_id"),
+            "WorkspaceID": Run._normalize_required_string(workspace_id, "workspace_id"),
+        }
+        if page_number is not None:
+            params["PageNumber"] = int(page_number)
+        if page_size is not None:
+            params["PageSize"] = int(page_size)
+        if top is not None:
+            params["Top"] = top
+        return Config.service().list_tasks(params)
+
+    @staticmethod
+    def get_task_metric_data_for_run(workspace_id: str,
+                                     run_id: str,
+                                     name: str,
+                                     period: str,
+                                     start_time: int,
+                                     end_time: int,
+                                     top: Optional[dict] = None) -> dict:
+        """Gets metric data for a task under a run."""
+        params = {
+            "Name": Run._normalize_required_string(name, "name"),
+            "RunID": Run._normalize_required_string(run_id, "run_id"),
+            "Period": Run._normalize_required_string(period, "period"),
+            "StartTime": Run._normalize_metric_time(start_time, "start_time"),
+            "EndTime": Run._normalize_metric_time(end_time, "end_time"),
+            "WorkspaceID": Run._normalize_required_string(workspace_id, "workspace_id"),
+        }
+        if top is not None:
+            params["Top"] = top
+        return Config.service().get_task_metric_data(params)
+
     @property
     def status(self) -> RUN_STATUS:
         """Returns the Run status.
@@ -166,14 +228,45 @@ class Run(metaclass=SingletonType):  # 单例模式，why
             res = self._tasks.query("Status=='Running'")
             if res.empty:
                 return self._tasks
-        tasks = Config.service().list_tasks({
-            "RunID": self.id,
-            "WorkspaceID": self.workspace_id
-        }).get("Items")
+        tasks = Run.list_tasks(
+            workspace_id=self.workspace_id,
+            run_id=self.id,
+        ).get("Items")
         if len(tasks) == 0:
             return None
         self._tasks = pd.DataFrame.from_records(tasks)
         return self._tasks
+
+    def get_task_metric_data(self,
+                             name: str,
+                             period: str,
+                             start_time: int,
+                             end_time: int,
+                             top: Optional[dict] = None) -> dict:
+        """Returns metric data for a task in this Run.
+
+        :param name: Task name
+        :type name: str
+        :param period: Metric interval granularity
+        :type period: str
+        :param start_time: Start timestamp
+        :type start_time: int
+        :param end_time: End timestamp
+        :type end_time: int
+        :param top: Optional top-level request metadata
+        :type top: dict
+        :return: Task metric data
+        :rtype: dict
+        """
+        return Run.get_task_metric_data_for_run(
+            workspace_id=self.workspace_id,
+            run_id=self.id,
+            name=name,
+            period=period,
+            start_time=start_time,
+            end_time=end_time,
+            top=top,
+        )
 
     @property
     def engine_run_id(self) -> str:
@@ -212,6 +305,20 @@ class Run(metaclass=SingletonType):  # 单例模式，why
             self._duration = item.get("Duration")
             self._log = item.get("Log")
             self._error = item.get("Message")
+
+    @staticmethod
+    def _normalize_metric_time(value: int, name: str) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise ParameterError(name, "must be an integer timestamp") from exc
+
+    @staticmethod
+    def _normalize_required_string(value: str, name: str) -> str:
+        normalized = str(value).strip() if value is not None else ""
+        if not normalized:
+            raise ParameterError(name)
+        return normalized
 
 
 class Submission(metaclass=SingletonType):  # 与run class行为相同
@@ -948,4 +1055,3 @@ class Workflow(metaclass=SingletonType):
         submission_id = Config.service().create_submission(params).get("ID")
 
         return Submission(self.workspace_id, submission_id).runs
-

--- a/bioos/service/BioOsService.py
+++ b/bioos/service/BioOsService.py
@@ -167,6 +167,11 @@ class BioOsService(Service):
                 'Action': 'ListTasks',
                 'Version': '2021-03-04'
             }, {}, {}),
+            'GetTaskMetricData':
+            ApiInfo('POST', '/', {
+                'Action': 'GetTaskMetricData',
+                'Version': '2021-03-04'
+            }, {}, {}),
             'GetTOSAccess':
             ApiInfo('POST', '/', {
                 'Action': 'GetTOSAccess',
@@ -339,6 +344,9 @@ class BioOsService(Service):
 
     def list_tasks(self, params):
         return self.__request('ListTasks', params)
+
+    def get_task_metric_data(self, params):
+        return self.__request('GetTaskMetricData', params)
 
     def get_tos_access(self, params):
         return self.__request('GetTOSAccess', params)

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -25,10 +25,12 @@ from bioos.cli import (
     get_workspace_profile,
     list_bioos_workspaces,
     list_files_from_workspace,
+    list_ies_apps,
     list_workspace_members,
     list_submissions_from_workspace,
     list_workflows_from_workspace,
     main as cli_main,
+    run as run_commands,
     search_dockstore,
     upload_dashboard_file,
     upload_files_to_workspace,
@@ -84,6 +86,80 @@ class TestCliHandlers(unittest.TestCase):
             page_size=10,
         )
         self.assertEqual(result, [{"ID": "sub1"}])
+
+    def test_run_list_handle(self):
+        args = SimpleNamespace(
+            workspace_name="ws",
+            submission_id="sid",
+            page_number=2,
+            page_size=50,
+            keyword="kw",
+            run_id=["rid"],
+            status=["Running"],
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        with patch("bioos.cli.run.login_with_args"), \
+                patch("bioos.cli.run.resolve_workspace", return_value=("wid", {})), \
+                patch("bioos.cli.run.Run.list_runs", return_value={"Items": []}) as mocked:
+            result = run_commands.handle_list(args)
+        self.assertEqual(result, {"Items": []})
+        mocked.assert_called_once_with(
+            workspace_id="wid",
+            submission_id="sid",
+            page_number=2,
+            page_size=50,
+            filter_={"Keyword": "kw", "IDs": ["rid"], "Status": ["Running"]},
+        )
+
+    def test_run_tasks_handle(self):
+        args = SimpleNamespace(
+            workspace_name="ws",
+            run_id="rid",
+            page_number=1,
+            page_size=0,
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        with patch("bioos.cli.run.login_with_args"), \
+                patch("bioos.cli.run.resolve_workspace", return_value=("wid", {})), \
+                patch("bioos.cli.run.Run.list_tasks", return_value={"Items": []}) as mocked:
+            result = run_commands.handle_tasks(args)
+        self.assertEqual(result, {"Items": []})
+        mocked.assert_called_once_with(
+            workspace_id="wid",
+            run_id="rid",
+            page_number=1,
+            page_size=0,
+        )
+
+    def test_run_metric_data_handle(self):
+        args = SimpleNamespace(
+            workspace_name="ws",
+            run_id="rid",
+            task_name="task.name",
+            period="60s",
+            start_time=100,
+            end_time=200,
+            ak="ak",
+            sk="sk",
+            endpoint="ep",
+        )
+        with patch("bioos.cli.run.login_with_args"), \
+                patch("bioos.cli.run.resolve_workspace", return_value=("wid", {})), \
+                patch("bioos.cli.run.Run.get_task_metric_data_for_run", return_value={"Status": "Running"}) as mocked:
+            result = run_commands.handle_metric_data(args)
+        self.assertEqual(result, {"Status": "Running"})
+        mocked.assert_called_once_with(
+            workspace_id="wid",
+            run_id="rid",
+            name="task.name",
+            period="60s",
+            start_time=100,
+            end_time=200,
+        )
 
     def test_generate_inputs_json_template_handle(self):
         args = SimpleNamespace(workspace_name="ws", workflow_name="wf")
@@ -207,6 +283,16 @@ class TestCliHandlers(unittest.TestCase):
             result = check_ies_status.handle(args)
         self.assertEqual(result["status"], "Running")
         self.assertEqual(result["list_record"], {"Name": "ies"})
+
+    def test_list_ies_apps_handle(self):
+        args = SimpleNamespace(workspace_name="ws")
+        ws = MagicMock()
+        ws.webinstanceapps.list.return_value = MagicMock()
+        with patch("bioos.cli.list_ies_apps.workspace_context_from_args", return_value=("wid", ws)), \
+                patch("bioos.cli.list_ies_apps.dataframe_records", return_value=[{"Name": "ies"}]):
+            result = list_ies_apps.handle(args)
+        ws.webinstanceapps.list.assert_called_once_with()
+        self.assertEqual(result, [{"Name": "ies"}])
 
     def test_get_ies_events_handle(self):
         args = SimpleNamespace(workspace_name="ws", ies_name="ies")
@@ -620,6 +706,83 @@ class TestCliRootAndAuth(unittest.TestCase):
                     "--output",
                     "json",
                 ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_run_list_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.run.handle_list", return_value={"Items": []}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "run",
+                    "list",
+                    "--workspace-name",
+                    "ws",
+                    "--submission-id",
+                    "sid",
+                    "--run-id",
+                    "rid",
+                    "--status",
+                    "Running",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_run_tasks_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.run.handle_tasks", return_value={"Items": []}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "run",
+                    "tasks",
+                    "--workspace-name",
+                    "ws",
+                    "--run-id",
+                    "rid",
+                    "--page-size",
+                    "0",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_run_metric_data_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.run.handle_metric_data", return_value={"Status": "Running"}) as mocked:
+            exit_code = cli_main.main(
+                [
+                    "run",
+                    "metric-data",
+                    "--workspace-name",
+                    "ws",
+                    "--run-id",
+                    "rid",
+                    "--task-name",
+                    "task.name",
+                    "--period",
+                    "60s",
+                    "--start-time",
+                    "100",
+                    "--end-time",
+                    "200",
+                    "--output",
+                    "json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
+    def test_root_ies_list_dispatches_to_existing_handler(self):
+        with patch("bioos.cli.list_ies_apps.handle", return_value=[{"Name": "ies"}]) as mocked:
+            exit_code = cli_main.main(
+                ["ies", "list", "--workspace-name", "ws", "--output", "json"]
             )
 
         self.assertEqual(exit_code, 0)

--- a/tests/test_ops_unit.py
+++ b/tests/test_ops_unit.py
@@ -8,10 +8,11 @@ from unittest.mock import MagicMock, patch
 
 from requests.exceptions import SSLError
 
-from bioos.ops import docker_build, dockstore, workspace_files
+from bioos.ops import docker_build, dockstore, formatters, workspace_files
 from bioos.internal.tos import TOSHandler
 from bioos.resource.files import FileResource
 from bioos.resource.usage import UsageResource
+from bioos.resource.workflows import Run
 from bioos.resource.workspaces import Workspace
 from bioos.service.BioOsService import BioOsService
 from network import config as repository_internal
@@ -88,6 +89,27 @@ class TestOpsHelpers(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["count"], 1)
 
+    def test_dataframe_records_converts_missing_values_to_none(self):
+        import pandas as pd
+
+        df = pd.DataFrame.from_records([{
+            "Name": "ies",
+            "Description": float("nan"),
+            "Status": {
+                "State": "Running",
+                "Message": float("nan"),
+            },
+        }])
+
+        self.assertEqual(formatters.dataframe_records(df), [{
+            "Name": "ies",
+            "Description": None,
+            "Status": {
+                "State": "Running",
+                "Message": None,
+            },
+        }])
+
     def test_fetch_wdl_from_dockstore_url(self):
         with tempfile.TemporaryDirectory() as tmpdir, \
                 patch("bioos.ops.dockstore._get_published_workflows", return_value=[{
@@ -117,7 +139,12 @@ class TestOpsHelpers(unittest.TestCase):
             ws = MagicMock()
             ws.files.s3_urls.return_value = ["s3://bioos-wid/__dashboard__.md"]
             ws.files.tos_handler.object_exists.return_value = False
-            ws.files.tos_handler.upload_objects.return_value = []
+            ws.files.tos_handler.build_upload_plan.return_value = [{
+                "source": str(dashboard),
+                "key": "__dashboard__.md",
+                "from_directory": False,
+            }]
+            ws.files.tos_handler.upload_planned_objects.return_value = []
             with patch("bioos.ops.workspace_files.login_to_bioos"), \
                     patch("bioos.ops.workspace_files.resolve_workspace", return_value=("wid", {})), \
                     patch("bioos.bioos.workspace", return_value=ws):
@@ -134,7 +161,19 @@ class TestOpsHelpers(unittest.TestCase):
             ws = MagicMock()
             ws.files.s3_urls.side_effect = lambda keys: [f"s3://bioos-wid/{keys[0]}"]
             ws.files.tos_handler.object_exists.side_effect = [True, False]
-            ws.files.tos_handler.upload_objects.return_value = []
+            ws.files.tos_handler.build_upload_plan.return_value = [
+                {
+                    "source": str(local_a),
+                    "key": "input_provision/a.txt",
+                    "from_directory": False,
+                },
+                {
+                    "source": str(local_b),
+                    "key": "input_provision/b.txt",
+                    "from_directory": False,
+                },
+            ]
+            ws.files.tos_handler.upload_planned_objects.return_value = []
 
             with patch("bioos.ops.workspace_files.login_to_bioos"), \
                     patch("bioos.ops.workspace_files.resolve_workspace", return_value=("wid", {})), \
@@ -157,10 +196,12 @@ class TestOpsHelpers(unittest.TestCase):
         self.assertEqual(result["workspace_id"], "wid")
         self.assertEqual(result["uploaded_count"], 1)
         self.assertEqual(result["skipped_count"], 1)
-        ws.files.tos_handler.upload_objects.assert_called_once_with(
-            files_to_upload=[str(local_b)],
-            target_path="input_provision/",
-            flatten=True,
+        ws.files.tos_handler.upload_planned_objects.assert_called_once_with(
+            upload_plan=[{
+                "source": str(local_b),
+                "key": "input_provision/b.txt",
+                "s3_url": "s3://bioos-wid/input_provision/b.txt",
+            }],
             checkpoint_dir=str(Path(tmpdir) / "checkpoints"),
             max_retries=5,
             task_num=8,
@@ -173,7 +214,12 @@ class TestOpsHelpers(unittest.TestCase):
             ws = MagicMock()
             ws.files.s3_urls.side_effect = lambda keys: [f"s3://bioos-wid/{keys[0]}"]
             ws.files.tos_handler.object_exists.return_value = False
-            ws.files.tos_handler.upload_objects.return_value = []
+            ws.files.tos_handler.build_upload_plan.return_value = [{
+                "source": str(local_a),
+                "key": "input_provision/a.txt",
+                "from_directory": False,
+            }]
+            ws.files.tos_handler.upload_planned_objects.return_value = []
 
             result = workspace_files._upload_local_files_with_workspace(
                 ws=ws,
@@ -190,7 +236,71 @@ class TestOpsHelpers(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertEqual(result["uploaded_count"], 1)
-        ws.files.tos_handler.upload_objects.assert_called_once()
+        ws.files.tos_handler.upload_planned_objects.assert_called_once()
+
+    def test_upload_local_directory_with_workspace_preserves_structure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "data"
+            nested = root / "nested"
+            nested.mkdir(parents=True)
+            local_a = root / "a.txt"
+            local_b = nested / "b.txt"
+            local_a.write_text("a", encoding="utf-8")
+            local_b.write_text("b", encoding="utf-8")
+
+            ws = MagicMock()
+            ws.files.s3_urls.side_effect = lambda keys: [f"s3://bioos-wid/{keys[0]}"]
+            ws.files.tos_handler = TOSHandler(client=MagicMock(), bucket="bucket")
+            ws.files.tos_handler.upload_planned_objects = MagicMock(return_value=[])
+
+            result = workspace_files._upload_local_files_with_workspace(
+                ws=ws,
+                workspace_id="wid",
+                workspace_name="ws",
+                sources=[str(root)],
+                target="input_provision/",
+                flatten=False,
+                skip_existing=False,
+                checkpoint_dir=str(Path(tmpdir) / "checkpoints"),
+                max_retries=2,
+                task_num=4,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["uploaded_count"], 2)
+        uploaded_keys = [item["key"] for item in result["uploaded_files"]]
+        self.assertEqual(uploaded_keys, [
+            "input_provision/data/a.txt",
+            "input_provision/data/nested/b.txt",
+        ])
+        ws.files.tos_handler.upload_planned_objects.assert_called_once()
+
+    def test_upload_local_directory_flatten_detects_conflicting_keys(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "data"
+            nested_a = root / "one"
+            nested_b = root / "two"
+            nested_a.mkdir(parents=True)
+            nested_b.mkdir(parents=True)
+            (nested_a / "sample.txt").write_text("a", encoding="utf-8")
+            (nested_b / "sample.txt").write_text("b", encoding="utf-8")
+
+            ws = MagicMock()
+            ws.files.tos_handler = TOSHandler(client=MagicMock(), bucket="bucket")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "Multiple local files map to target key 'input_provision/sample.txt'",
+            ):
+                workspace_files._upload_local_files_with_workspace(
+                    ws=ws,
+                    workspace_id="wid",
+                    workspace_name="ws",
+                    sources=[str(root)],
+                    target="input_provision/",
+                    flatten=True,
+                    skip_existing=False,
+                )
 
     def test_tos_handler_upload_objects_uses_checkpoint_and_retries(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -219,6 +329,35 @@ class TestOpsHelpers(unittest.TestCase):
         self.assertEqual(first_call["task_num"], 4)
         self.assertTrue(first_call["enable_checkpoint"])
         self.assertTrue(first_call["checkpoint_file"].endswith(".upload.ckpt"))
+
+    def test_file_resource_upload_accepts_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "data"
+            root.mkdir()
+            local_file = root / "a.txt"
+            local_file.write_text("a", encoding="utf-8")
+
+            resource = FileResource.__new__(FileResource)
+            resource.tos_handler = TOSHandler(client=MagicMock(), bucket="bucket")
+            resource.tos_handler.upload_planned_objects = MagicMock(return_value=[])
+
+            success = resource.upload(
+                sources=str(root),
+                target="input_provision/",
+                flatten=False,
+            )
+
+        self.assertTrue(success)
+        resource.tos_handler.upload_planned_objects.assert_called_once_with(
+            upload_plan=[{
+                "source": str(local_file),
+                "key": "input_provision/data/a.txt",
+                "from_directory": True,
+            }],
+            checkpoint_dir="",
+            max_retries=3,
+            task_num=10,
+        )
 
     def test_file_resource_download_accepts_workspace_s3_url(self):
         resource = FileResource.__new__(FileResource)
@@ -890,6 +1029,88 @@ class TestOpsHelpers(unittest.TestCase):
                 "This usage API is only available to the account owner",
             ):
                 usage.list_user_resource_usage(1, 2)
+
+    def test_bioos_service_registers_get_task_metric_data(self):
+        api_info = BioOsService.get_api_info()
+        self.assertIn("GetTaskMetricData", api_info)
+
+    def test_run_list_runs_builds_request(self):
+        response = {"Items": []}
+
+        with patch("bioos.resource.workflows.Config.service") as service_mock:
+            service_mock.return_value.list_runs.return_value = response
+            result = Run.list_runs(
+                workspace_id="wid",
+                submission_id="sid",
+                page_number=2,
+                page_size=50,
+                filter_={"Status": ["Running"]},
+            )
+
+        self.assertEqual(result, response)
+        service_mock.return_value.list_runs.assert_called_once_with(
+            {
+                "SubmissionID": "sid",
+                "WorkspaceID": "wid",
+                "PageNumber": 2,
+                "PageSize": 50,
+                "Filter": {"Status": ["Running"]},
+            }
+        )
+
+    def test_run_list_tasks_builds_request(self):
+        response = {"Items": []}
+
+        with patch("bioos.resource.workflows.Config.service") as service_mock:
+            service_mock.return_value.list_tasks.return_value = response
+            result = Run.list_tasks(
+                workspace_id="wid",
+                run_id="rid",
+                page_number=1,
+                page_size=0,
+            )
+
+        self.assertEqual(result, response)
+        service_mock.return_value.list_tasks.assert_called_once_with(
+            {
+                "RunID": "rid",
+                "WorkspaceID": "wid",
+                "PageNumber": 1,
+                "PageSize": 0,
+            }
+        )
+
+    def test_run_get_task_metric_data_builds_request(self):
+        run = Run.__new__(Run)
+        run.workspace_id = "wid"
+        run.id = "rid"
+        response = {
+            "Status": "Running",
+            "DataPointsCPUUsage": [{"Timestamp": 1, "Value": 0.5}],
+        }
+
+        with patch("bioos.resource.workflows.Config.service") as service_mock:
+            service_mock.return_value.get_task_metric_data.return_value = response
+            result = run.get_task_metric_data(
+                name=" task.name ",
+                period="60s",
+                start_time="100",
+                end_time=200,
+                top={"RequestId": "req-1"},
+            )
+
+        self.assertEqual(result, response)
+        service_mock.return_value.get_task_metric_data.assert_called_once_with(
+            {
+                "Name": "task.name",
+                "RunID": "rid",
+                "Period": "60s",
+                "StartTime": 100,
+                "EndTime": 200,
+                "WorkspaceID": "wid",
+                "Top": {"RequestId": "req-1"},
+            }
+        )
 
     def test_workspace_list_members_defaults_to_in_workspace_filter(self):
         workspace = Workspace.__new__(Workspace)


### PR DESCRIPTION
## Summary

This PR adds new Bio-OS CLI capabilities around file upload, IES listing, and run/resource inspection.

### Changes

- Support uploading local directories with `bioos file upload`
  - `--source` now accepts files or directories
  - default `--flatten` behavior is preserved
  - `--no-flatten` preserves directory structure under the target prefix
  - detects duplicate target keys before upload
  - supports `--skip-existing` for directory uploads

- Add IES list CLI
  - `bioos ies list --workspace-name <workspace>`

- Add Run / Task / Metric query CLI
  - `bioos run list --workspace-name <workspace> --submission-id <submission>`
  - `bioos run tasks --workspace-name <workspace> --run-id <run>`
  - `bioos run metric-data --workspace-name <workspace> --run-id <run> --task-name <task> --period <period> --start-time <ts> --end-time <ts>`

- Improve JSON output safety
  - normalize NaN-like values to `null` for structured CLI output

- Add unit tests for the new CLI handlers, upload planning, formatter behavior, and run metric APIs
