### PR TITLE
Fix workflow import local WDL handling

### DIFF
--- a/bioos/bw_import.py
+++ b/bioos/bw_import.py
@@ -5,8 +5,13 @@ import time
 
 from bioos import bioos
 from bioos.config import DEFAULT_ENDPOINT
+from bioos.errors import ParameterError
 from bioos.ops.auth import login_to_bioos, resolve_workspace
-from bioos.resource.workflows import WorkflowResource
+from bioos.resource.workflows import (
+    GIT_WORKFLOW_IMPORT_DISABLED_MESSAGE,
+    WorkflowResource,
+    is_git_workflow_source,
+)
 
 
 def get_logger():
@@ -31,16 +36,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--sk', required=False, help='Secret key for your Bio-OS instance platform account')
     parser.add_argument('--workspace_name', required=True, help='Target workspace name')
     parser.add_argument('--workflow_name', required=True, help='Name for the workflow to be imported')
-    parser.add_argument('--workflow_source', required=True, help='Local WDL file path or git repository URL')
+    parser.add_argument('--workflow_source', required=True,
+                        help='Local .wdl file path or local directory containing WDL files')
     parser.add_argument('--endpoint', help='Bio-OS instance platform endpoint', default=DEFAULT_ENDPOINT)
     parser.add_argument('--workflow_desc', help='Description for the workflow', default='')
-    parser.add_argument('--main_path', help='Main workflow file path (required for git repository)', default='')
+    parser.add_argument('--main_path', help='Main workflow file path for local WDL directory imports', default='')
     parser.add_argument('--monitor', action='store_true', help='Monitor the workflow validation status until completion')
     parser.add_argument('--monitor_interval', type=int, default=60, help='Time interval in seconds for checking workflow status')
     return parser
 
 
 def handle(args) -> str:
+    if is_git_workflow_source(args.workflow_source):
+        raise ParameterError("workflow_source", GIT_WORKFLOW_IMPORT_DISABLED_MESSAGE)
+
     logger = get_logger()
     login_to_bioos(access_key=args.ak, secret_key=args.sk, endpoint=args.endpoint)
     workspace_id, _ = resolve_workspace(args.workspace_name)

--- a/bioos/cli/main.py
+++ b/bioos/cli/main.py
@@ -315,9 +315,20 @@ def _add_workflow_group(subparsers: Any) -> None:
     add_output_arguments(import_parser)
     add_argument(import_parser, "workspace_name", required=True, help="Workspace name.")
     add_argument(import_parser, "workflow_name", required=True, help="Workflow name.")
-    add_argument(import_parser, "workflow_source", required=True, help="Local WDL file path or git repository URL.")
+    add_argument(
+        import_parser,
+        "workflow_source",
+        required=True,
+        help="Local .wdl file path or local directory containing WDL files.",
+    )
     add_argument(import_parser, "workflow_desc", required=False, default="", help="Workflow description.")
-    add_argument(import_parser, "main_path", required=False, default="", help="Main workflow file path.")
+    add_argument(
+        import_parser,
+        "main_path",
+        required=False,
+        default="",
+        help="Main workflow file path for local WDL directory imports.",
+    )
     add_bool_argument(import_parser, "monitor", default=False, help_text="Monitor the workflow import status.")
     add_argument(
         import_parser,

--- a/bioos/resource/workflows.py
+++ b/bioos/resource/workflows.py
@@ -20,6 +20,22 @@ UNKNOWN = "Unknown"
 SUBMISSION_STATUS = Literal["Succeeded", "Failed", "Running", "Pending"]
 RUN_STATUS = Literal["Succeeded", "Failed", "Running", "Pending"]
 WORKFLOW_LANGUAGE = Literal["WDL"]
+GIT_WORKFLOW_IMPORT_DISABLED_MESSAGE = (
+    "Git URL workflow import is currently disabled. Please clone or download "
+    "the repository first, then import a local .wdl file or a local directory "
+    "containing WDL files."
+)
+_GIT_WORKFLOW_IMPORT_ENV = "BIOOS_ENABLE_GIT_WORKFLOW_IMPORT"
+
+
+def is_git_workflow_source(source: str) -> bool:
+    value = (source or "").strip().lower()
+    return value.startswith(("http://", "https://", "git://", "ssh://", "git@"))
+
+
+def _git_workflow_import_enabled() -> bool:
+    value = os.environ.get(_GIT_WORKFLOW_IMPORT_ENV, "")
+    return value.lower() in {"1", "true", "yes", "on"}
 
 
 def zip_files(source_files, zip_type='base64'):
@@ -499,10 +515,10 @@ class WorkflowResource(metaclass=SingletonType):
         ::
 
             ws = bioos.workspace("foo")
-            ws.workflows.import_workflow(source = "http://foo.git", name = "bar",  description = "",
-            language = "WDL", tag = "baz", token = "xxxxxxxx", main_workflow_path = "aaa/bbb.wdl")
+            ws.workflows.import_workflow(source = "./workflow.wdl", name = "bar", description = "",
+            language = "WDL")
 
-        :param source: git source of workflow
+        :param source: local WDL file path or local directory containing WDL files
         :type source: str
         :param name: The name of specified workflow
         :type name: str
@@ -510,15 +526,20 @@ class WorkflowResource(metaclass=SingletonType):
         :type description: str
         :param language: The language of specified workflow
         :type language: str
-        :param tag: The tag of specified workflow
+        :param tag: Deprecated. Git URL workflow import is currently disabled;
+            this value is ignored for local WDL imports.
         :type tag: str
-        :param token: The token of specified workflow
+        :param token: Deprecated. Reserved for the disabled Git URL import path;
+            not needed for local WDL imports.
         :type token: str
         :param main_workflow_path: Main path of specified workflow
         :type main_workflow_path: str
         :return: Workflow ID
         :rtype: str
         """
+        if is_git_workflow_source(source) and not _git_workflow_import_enabled():
+            raise ParameterError("source", GIT_WORKFLOW_IMPORT_DISABLED_MESSAGE)
+
         if name:  # 流程是否存在
             exist = Config.service().check_workflow({
                 "WorkspaceID": self.workspace_id,
@@ -534,6 +555,8 @@ class WorkflowResource(metaclass=SingletonType):
             raise ParameterError("language", f"Unsupported language: '{language}'. Only 'WDL' is supported.")
 
         if source.startswith("http://") or source.startswith("https://"):
+            # Legacy Git import path retained behind BIOOS_ENABLE_GIT_WORKFLOW_IMPORT
+            # for maintainers while public CLI/SDK usage defaults to local WDL only.
             params = {
                 "WorkspaceID": self.workspace_id,
                 "Name": name,
@@ -556,9 +579,11 @@ class WorkflowResource(metaclass=SingletonType):
                     if file.endswith('.wdl'):
                         full_path = os.path.join(root, file)
                         relative_path = os.path.relpath(full_path, source)  # 获取文件相对于source的相对路径。
+                        with open(full_path, "rb") as handle:
+                            origin_file = handle.read()
                         source_files.append({
                             "name": relative_path,  # 使用相对路径
-                            "originFile": open(full_path, "rb").read()
+                            "originFile": origin_file
                         })
 
             if not source_files:
@@ -566,9 +591,20 @@ class WorkflowResource(metaclass=SingletonType):
 
             # 确保主工作流路径是相对路径
             if main_workflow_path:
-                if not os.path.exists(main_workflow_path):
+                source_abs = os.path.abspath(source)
+                if os.path.isabs(main_workflow_path):
+                    main_abs = os.path.abspath(main_workflow_path)
+                else:
+                    main_abs = os.path.abspath(os.path.join(source_abs, main_workflow_path))
+
+                if not os.path.isfile(main_abs):
                     raise ParameterError("main_workflow_path", f"Main workflow file {main_workflow_path} not found")
-                main_relative = os.path.relpath(main_workflow_path, source)
+                if os.path.commonpath([source_abs, main_abs]) != source_abs:
+                    raise ParameterError(
+                        "main_workflow_path",
+                        "Main workflow file must be inside the workflow source directory",
+                    )
+                main_relative = os.path.relpath(main_abs, source_abs)
             else:
                 main_relative = None
 
@@ -583,16 +619,18 @@ class WorkflowResource(metaclass=SingletonType):
                 "Content": zip_base64,
             }
             if main_relative:
-                params["MainWorkflowPath"] = os.path.basename(main_relative)
+                params["MainWorkflowPath"] = main_relative
             if token:
                 params["Token"] = token
 
             return Config.service().create_workflow(params)
         #单文件上传
         elif os.path.isfile(source) and source.endswith('.wdl'):
+            with open(source, "rb") as handle:
+                origin_file = handle.read()
             source_files = [{
                 "name": os.path.basename(source),
-                "originFile": open(source, "rb").read()
+                "originFile": origin_file
             }]
             zip_base64 = zip_files(source_files, 'base64')
 

--- a/bioos/tests/workflows.py
+++ b/bioos/tests/workflows.py
@@ -36,7 +36,7 @@ class TestWorkflows(BaseInit):
     list_workflows_val = {'Items': [
         {'ID': workflow_id, 'Name': workflow_name, 'Description': '[dockstore]',
          'CreateTime': 1670929870, 'UpdateTime': 1671032374, 'Language': 'WDL',
-         'Source': 'https://github.com/fake/hello.git', 'Tag': 'main',
+         'Source': './hello.wdl', 'Tag': '',
          'MainWorkflowPath': 'hello.wdl',
          'Status': {'Phase': 'Failed',
                     'Message': 'job failed: Reason=BackoffLimitExceeded, '
@@ -143,8 +143,8 @@ class TestWorkflows(BaseInit):
                      'UpdateTime': pandas.to_datetime(1671032374,
                                                       unit='ms',
                                                       origin=pandas.Timestamp('2018-07-01')),
-                     'Language': 'WDL', 'Source': 'https://github.com/fake/hello.git',
-                     'Tag': 'main', 'MainWorkflowPath': 'hello.wdl'}
+                     'Language': 'WDL', 'Source': './hello.wdl',
+                     'Tag': '', 'MainWorkflowPath': 'hello.wdl'}
                 ]))
                 success_list_workflows.assert_has_calls([
                     mock.call({
@@ -169,10 +169,16 @@ class TestWorkflows(BaseInit):
         with patch.object(BioOsService, "check_workflow",
                           return_value={'IsNameExist': False}) as success_check:
             with patch.object(BioOsService, "create_workflow",
-                              return_value={'ID': self.workflow_id}) as success_create:
-                workflow_id = self.workflows.import_workflow("https://github.com/fake/hello.git",
-                                                             self.workflow_name, "WDL", "main",
-                                                             "hello.wdl", "[dockstore]")
+                              return_value=self.workflow_id) as success_create:
+                with patch("bioos.resource.workflows.os.path.isfile",
+                           return_value=True):
+                    with patch("bioos.resource.workflows.zip_files",
+                               return_value="zip-content"):
+                        with patch("builtins.open",
+                                   mock.mock_open(read_data=b"workflow {}")):
+                            workflow_id = self.workflows.import_workflow("./hello.wdl",
+                                                                         self.workflow_name,
+                                                                         "[dockstore]")
                 self.assertEqual(workflow_id, self.workflow_id)
         success_check.assert_called_once_with({
             "WorkspaceID": self.workspace_id,
@@ -183,8 +189,8 @@ class TestWorkflows(BaseInit):
             "Name": self.workflow_name,
             "Description": "[dockstore]",
             "Language": "WDL",
-            "Source": "https://github.com/fake/hello.git",
-            "Tag": "main",
+            "SourceType": "file",
+            "Content": "zip-content",
             "MainWorkflowPath": "hello.wdl",
         })
 
@@ -192,8 +198,8 @@ class TestWorkflows(BaseInit):
                           return_value={'IsNameExist': True}) as success_check:
             with patch.object(BioOsService, "create_workflow") as miss_create:
                 try:
-                    self.workflows.import_workflow("https://github.com/fake/hello.git",
-                                                   self.workflow_name, "WDL", "main", "hello.wdl",
+                    self.workflows.import_workflow("./hello.wdl",
+                                                   self.workflow_name,
                                                    "[dockstore]")
                 except ConflictError as e:
                     self.assertEqual(e.message, f"parameter 'name' conflicts: "

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -38,6 +38,7 @@ from bioos.cli import (
     update_workspace_members,
 )
 from bioos import bioos_workflow, bw_import, bw_import_status_check, bw_status_check, get_submission_logs as submission_logs_module
+from bioos.errors import ParameterError
 from bioos.ops import auth as auth_ops
 from network.cli import main as network_cli
 
@@ -920,6 +921,24 @@ class TestCliRootAndAuth(unittest.TestCase):
 
         login_mock.assert_called_once()
         self.assertIn("still validating", result)
+
+    def test_legacy_workflow_import_rejects_git_url(self):
+        args = bw_import.build_parser().parse_args(
+            [
+                "--workspace_name",
+                "ws",
+                "--workflow_name",
+                "wf",
+                "--workflow_source",
+                "https://github.com/example/workflow.git",
+            ]
+        )
+
+        with patch("bioos.bw_import.login_to_bioos") as login_mock, \
+                self.assertRaisesRegex(ParameterError, "Git URL workflow import is currently disabled"):
+            bw_import.handle(args)
+
+        login_mock.assert_not_called()
 
     def test_legacy_workflow_submit_handle_uses_unified_login(self):
         args = bioos_workflow.build_parser().parse_args(

--- a/tests/test_ops_unit.py
+++ b/tests/test_ops_unit.py
@@ -10,9 +10,10 @@ from requests.exceptions import SSLError
 
 from bioos.ops import docker_build, dockstore, formatters, workspace_files
 from bioos.internal.tos import TOSHandler
+from bioos.errors import ParameterError
 from bioos.resource.files import FileResource
 from bioos.resource.usage import UsageResource
-from bioos.resource.workflows import Run
+from bioos.resource.workflows import Run, WorkflowResource
 from bioos.resource.workspaces import Workspace
 from bioos.service.BioOsService import BioOsService
 from network import config as repository_internal
@@ -51,6 +52,54 @@ class TestOpsHelpers(unittest.TestCase):
             )
             result = docker_build.check_build_status_request("task-1")
         self.assertEqual(result, {"Status": "Running"})
+
+    def test_workflow_import_rejects_git_url_by_default(self):
+        workflows = WorkflowResource("workspace-id")
+
+        with patch.object(BioOsService, "check_workflow") as check_mock, \
+                self.assertRaisesRegex(ParameterError, "Git URL workflow import is currently disabled"):
+            workflows.import_workflow(
+                source="https://github.com/example/workflow.git",
+                name="wf",
+                description="desc",
+            )
+
+        check_mock.assert_not_called()
+
+    def test_workflow_import_directory_preserves_nested_main_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir)
+            workflows_dir = source / "workflows"
+            tasks_dir = source / "tasks"
+            workflows_dir.mkdir()
+            tasks_dir.mkdir()
+            (workflows_dir / "main.wdl").write_text(
+                'version 1.0\nimport "../tasks/echo.wdl" as echo_tasks\nworkflow wf {}\n'
+            )
+            (tasks_dir / "echo.wdl").write_text("version 1.0\ntask echo_name { command <<< echo hi >>> }\n")
+
+            cases = [
+                ("absolute", str(workflows_dir / "main.wdl")),
+                ("relative", "workflows/main.wdl"),
+            ]
+            for label, main_path in cases:
+                with self.subTest(label=label), \
+                        patch("bioos.resource.workflows.Config.service") as service_mock:
+                    service = service_mock.return_value
+                    service.check_workflow.return_value = {"IsNameExist": False}
+                    service.create_workflow.return_value = "wf-id"
+
+                    result = WorkflowResource(f"workspace-{label}").import_workflow(
+                        source=str(source),
+                        name=f"wf-{label}",
+                        description="nested main path",
+                        main_workflow_path=main_path,
+                    )
+
+                    self.assertEqual(result, "wf-id")
+                    params = service.create_workflow.call_args.args[0]
+                    self.assertEqual(params["SourceType"], "file")
+                    self.assertEqual(params["MainWorkflowPath"], "workflows/main.wdl")
 
     def test_parse_workflow_url(self):
         org, workflow = dockstore.parse_workflow_url(


### PR DESCRIPTION
## Summary

This PR hotfixes workflow import behavior for local WDL uploads.

Changes:
- Disable Git URL workflow import by default in both CLI and SDK paths.
- Update CLI help text to only advertise local `.wdl` files and local WDL directories.
- Keep the legacy SDK Git import branch behind an internal opt-in gate for future follow-up.
- Fix local directory workflow imports so nested `--main-path` values preserve their path relative to `--workflow-source`.
- Support both absolute and source-relative `--main-path` values, e.g.:
  - `/path/to/workflows/main.wdl`
  - `workflows/main.wdl`
- Add tests for Git URL rejection and nested main WDL path preservation.

## Why

`bioos workflow import` previously advertised Git repository URLs as valid workflow sources, but the CLI did not expose a `tag` argument. For Git URL imports this could send an empty `Tag` to the backend and fail validation with `workflowTag`.

For now, Git URL import is not a supported user-facing path. This PR makes that explicit and prevents users or agents from accidentally taking that path.

This also fixes a separate local directory import bug where nested main WDL paths were reduced to `basename`, causing Bio-OS to receive `main.wdl` instead of `workflows/main.wdl`.